### PR TITLE
updated the description of rotate function

### DIFF
--- a/content/classes/2.2/AbstractMesh.md
+++ b/content/classes/2.2/AbstractMesh.md
@@ -346,6 +346,8 @@ Get the world matrix
 
 Rotate this mesh with the given axis and the given angle in the mesh's space
 
+Note: This function will switch the mesh rotation from euler to quaternion. The mesh's "rotation" property, which specifies the rotation in euler, will be not be updated and would, in fact, be set to zero if "rotationQuaternion" property was not set when this function was called.  The mesh's "rotationQuaternion" property will be set to the new rotation.
+
 ####Parameters
  | Name | Type | Description
 ---|---|---|---

--- a/content/classes/2.2/AbstractMesh.md
+++ b/content/classes/2.2/AbstractMesh.md
@@ -344,9 +344,9 @@ Get the world matrix
 
 ###rotate(axis, amount, space) &rarr; void
 
-Rotate this mesh with the given axis and the given angle in the mesh's space
+Rotate this mesh with the given axis and the given angle in the mesh's space.
 
-Note: This function will switch the mesh rotation from euler to quaternion. The mesh's "rotation" property, which specifies the rotation in euler, will be not be updated and would, in fact, be set to zero if "rotationQuaternion" property was not set when this function was called.  The mesh's "rotationQuaternion" property will be set to the new rotation.
+The mesh's "rotationQuaternion" property will be set to the new rotation. The mesh's "rotation" property will be set to zero if "rotationQuaternion" property was not set before.
 
 ####Parameters
  | Name | Type | Description


### PR DESCRIPTION
The rotate function resets the mesh "rotation" value  to zero which can lead to unexpected results for those  using "rotation". As such this behavior should be clarified.
