### PR TITLE
Category Map added

### DIFF
--- a/content/overviews/Maps/Documentation_Category_Map.md
+++ b/content/overviews/Maps/Documentation_Category_Map.md
@@ -1,0 +1,281 @@
+**Begin Here**  
+&nbsp;&nbsp;&nbsp;&nbsp;[A Babylon.js Primer](/generals/A_Babylon.js_Primer)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating a Basic Scene](/tutorials/Creating_a_Basic_Scene)  
+&nbsp;&nbsp;&nbsp;&nbsp;[The Playground Tutorial](/generals/The_Playground_Tutorial)  
+****  
+**BabylonHx**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Introduction](/extensions/introduction_babylonhx)  
+****  
+**Bones Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Bones and Skeletons](/tutorials/How_to_use_Bones_and_Skeletons)  
+****  
+**Camera Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Cameras](/tutorials/Cameras)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Cameras, Mesh Collisions and Gravity](/tutorials/Cameras,_Mesh_Collisions_and_Gravity)  
+****  
+**Camera Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Customizing camera inputs](/tutorials/Customizing_Camera_Inputs)  
+****  
+**Camera Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use VirtualJoysticksCamera](/tutorials/How_to_use_VirtualJoysticksCamera)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using depth-of-field and other lens effects](/tutorials/Using_depth-of-field_and_other_lens_effects)  
+****  
+**Canvas2d Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Canvas 2D overview and architecture](/overviews/Canvas2D_Overview_Architecture)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using the Canvas2D](/tutorials/Using_the_Canvas2D)  
+****  
+**Canvas2d Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Canvas 2D Home](/overviews/Canvas2D_Home)  
+****  
+**Canvas2d Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating your own primitive type for the Canvas2D](/tutorials/How_to_create_your_own_Canvas2D_primitive)  
+****  
+**Collisions Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Cameras, Mesh Collisions and Gravity](/tutorials/Cameras,_Mesh_Collisions_and_Gravity)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Intersect Collisions - mesh](/tutorials/Intersect_Collisions_-_mesh)  
+****  
+**Contributing**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Approved Naming Conventions](/generals/Approved_Naming_Conventions)  
+****  
+**Custom**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating the Mini-fied Version](/generals/Creating_the_Mini-fied_Version)  
+&nbsp;&nbsp;&nbsp;&nbsp;[FileFormat Map (.babylon)](/generals/File_Format_Map_%28.babylon%29)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Framework versions](/generals/Framework_versions)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Setup Visual Studio to contribute to Babylon.js](/generals/setup_visualStudio)  
+****  
+**Debugging Aid**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using the Debug Layer](/tutorials/Using_the_Debug_Layer)  
+****  
+**Editor**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Getting Started](/extensions/Getting_Started)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Introduction](/extensions/Introduction)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating Cinematic](/extensions/Creating_Cinematic)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating Materials](/extensions/Creating_Materials)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating Particle Systems](/extensions/Creating_Particle_Systems)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Managing Animations](/extensions/Managing_Animations)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Managing Lens Flare Systems](/extensions/Managin_Lens_Flare_Systems)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Managing Materials](/extensions/Managing_Materials)  
+****  
+**Environment Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Environment](/tutorials/Environment)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Height_Map](/tutorials/Height_Map)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Shadows](/tutorials/Shadows)  
+****  
+**Environment Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating a Convincing World](/tutorials/Creating_a_Convincing_World)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Supporting fog with ShaderMaterial](/tutorials/Supporting_fog_with_ShaderMaterial)  
+****  
+**Events Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Handling Babylon.js events with observables](/overviews/Observables)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Actions](/tutorials/How_to_use_Actions)  
+****  
+**Exporters 3DSMax**  
+&nbsp;&nbsp;&nbsp;&nbsp;[3DSMax](/exporters/3DSMax)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Bones influences per vertex](/exporters/Bones_influences_per_vertex)  
+****  
+**Exporters Blender**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Blender](/exporters/Blender)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Blender tips](/exporters/Blender_Tips)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Installing the Babylon Exporter](/exporters/Installing__the_Babylon_Exporter)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Working with Blender](/exporters/Working_with_Blender)  
+****  
+**Exporters Cheetah3D**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Cheetah3D](/exporters/Cheetah3D)  
+****  
+**Exporters Unity**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Unity](/exporters/Unity)  
+****  
+**Future**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Roadmap](/generals/Roadmap)  
+****  
+**Games Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating a 3D WebGL Procedural QR-Code Maze with Physics](/tutorials/Creating_a_3D_WebGL_Procedural_QR-Code_Maze_with_Physics)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating a Small 3D Game with Babylon.js](/tutorials/Creating_a_Small_3D_Game_with_Babylon.js)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using WebGL to Create Games for the Windows Store](/tutorials/Using_WebGL_to_Create_Games_for_the_Windows_Store)  
+****  
+**GUI -  bGUI**  
+&nbsp;&nbsp;&nbsp;&nbsp;[bGUI](/extensions/bGUI)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIGroup](/extensions/GUIGroup)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIObject](/extensions/GUIObject)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIPanel](/extensions/GUIPanel)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUISystem](/extensions/GUISystem)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIText](/extensions/GUIText)  
+****  
+**GUI -  CastorGUI**  
+&nbsp;&nbsp;&nbsp;&nbsp;[CastorGUI](/extensions/CastorGUI)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIButton](/extensions/GUIButton)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUICheckbox](/extensions/GUICheckbox)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIColor](/extensions/GUIColor)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIDialog](/extensions/GUIDialog)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIFieldset](/extensions/GUIFieldset)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIGroup](/extensions/GUIGroup)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUILabel](/extensions/GUILabel)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIManager](/extensions/GUIManager)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIMeter](/extensions/GUIMeter)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIPanel](/extensions/GUIPanel)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIProgress](/extensions/GUIProgress)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIRadio](/extensions/GUIRadio)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUISelect](/extensions/GUISelect)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUISlider](/extensions/GUISlider)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUISpinner](/extensions/GUISpinner)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIText](/extensions/GUIText)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUITextarea](/extensions/GUITextarea)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUITextfield](/extensions/GUITextfield)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUITextures](/extensions/GUITextures)  
+&nbsp;&nbsp;&nbsp;&nbsp;[GUIWindow](/extensions/GUIWindow)  
+****  
+**Lights Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Lights](/tutorials/Lights)  
+****  
+**Lights Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[More About Lights](/tutorials/More_About_Lights)  
+****  
+**Lights Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Lens Flares](/tutorials/How_to_use_Lens_Flares)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Layermasks and Multi-cam Textures](/tutorials/Layermasks_and_Multi-cam_Textures)  
+****  
+**Loaders**  
+&nbsp;&nbsp;&nbsp;&nbsp;[glTF](/extensions/glTF)  
+&nbsp;&nbsp;&nbsp;&nbsp;[OBJ](/extensions/OBJ)  
+&nbsp;&nbsp;&nbsp;&nbsp;[STL](/extensions/STL)  
+****  
+**Loader Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Caching Resources in IndexedDB](/tutorials/Caching_Resources_in_IndexedDB)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Creating a custom loading screen](/tutorials/Creating_a_custom_loading_screen)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Loading a Scene Produced with Blender](/tutorials/Loading_a_Scene_Produced_with_Blender)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using the Incremental Loading System](/tutorials/Using_the_Incremental_Loading_System)  
+****  
+**Loader Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to Create Your Own File Importer](/tutorials/How_to_Create_Your_Own_File_Importer)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use AssetsManager](/tutorials/How_to_use_AssetsManager)  
+****  
+**Material Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Materials](/tutorials/Materials)  
+****  
+**Material Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Advanced Texturing](/tutorials/Advanced_Texturing)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Introduction to Physically Based Rendering](/overviews/Physically_Based_Rendering)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Unleash the StandardMaterial](/tutorials/Unleash_the_StandardMaterial)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using Multi-Materials](/tutorials/Using_Multi-Materials)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using Parallax Mapping](/tutorials/Using_parallax_mapping)  
+****  
+**Material Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to create a material for the materials library](/tutorials/How_to_create_a_material_for_materialsLibrary)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to create a procedural texture for the procedural textures library](/tutorials/How_to_create_a_proceduralTexture_for_procedutalTexturesLibrary)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use DepthRenderer to get depth values](/tutorials/How_to_use_DepthRenderer_to_get_depth_values)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use FresnelParameters](/tutorials/How_to_use_FresnelParameters)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Procedural Textures](/tutorials/How_to_use_Procedural_Textures)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Reflection Probes](/tutorials/How_to_use_Reflection_probes)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Master the Physically Based Rendering](/overviews/Physically_Based_Rendering_Master)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Understanding Shaders with Babylon.js and ShaderMaterial](/tutorials/Understanding_Shaders_with_Babylon.js_and_ShaderMaterial)  
+****  
+**Materials library**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Fire](/extensions/fire)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Fur](/extensions/Fur)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Gradient](/extensions/Gradient)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Grid](/extensions/Grid)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Lava](/extensions/Lava)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Normal](/extensions/Normal)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Sky](/extensions/Sky)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Terrain](/extensions/Terrain)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Tri-Planar Mapping](/extensions/Tri_Planar_Mapping)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Water](/extensions/Water)  
+****  
+**Mesh Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Animations](/tutorials/Animations)  
+&nbsp;&nbsp;&nbsp;&nbsp;[CreateBox per face colors and textures tutorial](/tutorials/CreateBox_Per_Face_Textures_And_Colors)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Discover Basic Elements](/tutorials/Discover_Basic_Elements)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How Rotations and Translations Work](/overviews/How_Rotations_and_Translations_Work)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Intersect Collisions - mesh](/tutorials/Intersect_Collisions_-_mesh)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Mesh CreateXXX Methods With Options Parameter](/tutorials/Mesh_CreateXXX_Methods_With_Options_Parameter)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Parametric Shapes](/tutorials/Parametric_Shapes)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Picking Collisions](/tutorials/Picking_Collisions)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Position, Rotation, Scaling](/tutorials/Position,_Rotation,_Scaling)  
+****  
+**Mesh Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Position, Rotate, Translate and Spaces](/tutorials/Position,_Rotate,_Translate_and_Spaces)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Ribbon Tutorial](/tutorials/Ribbon_Tutorial)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using decals](/tutorials/Using_decals)  
+****  
+**Mesh Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to dynamically morph a mesh](/tutorials/How_to_dynamically_morph_a_mesh)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to Merge Meshes](/tutorials/How_to_Merge_Meshes)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Blend Modes](/tutorials/How_to_use_Blend_Modes)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use EdgesRenderer](/tutorials/How_to_use_EdgesRenderer)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Instances](/tutorials/How_to_use_Instances)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use LOD](/tutorials/How_to_use_LOD)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use the Tags System](/tutorials/How_to_use_the_Tags_System)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Tiled Grounds](/tutorials/How_to_use_Tiled_Grounds)  
+&nbsp;&nbsp;&nbsp;&nbsp;[In-Browser Mesh Simplification (Auto-LOD)](/tutorials/In-Browser_Mesh_Simplification_%28Auto-LOD%29)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Optimizing Your Scene with Octrees](/tutorials/Optimizing_Your_Scene_with_Octrees)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Transparency and How Meshes Are Rendered](/tutorials/Transparency_and_How_Meshes_Are_Rendered)  
+****  
+**Particles Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Particles](/tutorials/Particles)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use the Solid Particle System](/overviews/Solid_Particle_System)  
+****  
+**Paths Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Curve3](/tutorials/How_to_use_Curve3)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Path3D](/tutorials/How_to_use_Path3D)  
+****  
+**Physics Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Physics Engine - Basic Usage](/overviews/Using_The_Physics_Engine)  
+****  
+**Physics Intermediate**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using the Cannon.js Physics Engine](/tutorials/Using_the_Cannon.js_Physics_Engine)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using the Oimo.js Physics Engine](/tutorials/Using_the_Oimo.js_Physics_Engine)  
+****  
+**Physics Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Adding Your Own Physics Engine Plugin to Babylon.js](/tutorials/Adding_Your_Own_Physics_Engine_Plugin_to_Babylon.js)  
+****  
+**Playground Basics**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Interesting Playgrounds](/generals/playgrounds)  
+&nbsp;&nbsp;&nbsp;&nbsp;[The Playground Tutorial](/generals/The_Playground_Tutorial)  
+****  
+**Point of View Movement**  
+&nbsp;&nbsp;&nbsp;&nbsp;[POV](/extensions/POV)  
+****  
+**PostProcess Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use PostProcesses](/tutorials/How_to_use_PostProcesses)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use PostProcessRenderPipeline](/tutorials/How_to_use_PostProcessRenderPipeline)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using the HDR Rendering Pipeline](/tutorials/Using_the_HDR_Rendering_Pipeline)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using the SSAO rendering pipeline](/tutorials/Using_the_SSAO_rendering_pipeline)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using the Volumetric LightScattering post-process](/tutorials/Using_the_Volumetric_LightScattering_post-process)  
+****  
+**Scene Advanced**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use Multi-Views](/tutorials/How_to_use_Multi-Views)  
+&nbsp;&nbsp;&nbsp;&nbsp;[How to use SceneOptimizer](/tutorials/How_to_use_SceneOptimizer)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Optimizing your scene](/tutorials/Optimizing_your_scene)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Render Scene on a PNG](/tutorials/Render_Scene_on_a_PNG)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using logarithmic depth buffer](/tutorials/Using_logarithmic_depth_buffer)  
+****  
+**Sounds**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Playing sounds and music](/overviews/Playing_sounds_and_music)  
+****  
+**Sprites**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Sprites](/tutorials/Sprites)  
+****  
+**Transformations**  
+&nbsp;&nbsp;&nbsp;&nbsp;[How Rotations and Translations Work](/overviews/How_Rotations_and_Translations_Work)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Position, Rotation, Scaling](/tutorials/Position,_Rotation,_Scaling)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Position, Rotate, Translate and Spaces](/tutorials/Position,_Rotate,_Translate_and_Spaces)  
+****  
+**Tree Generators**  
+&nbsp;&nbsp;&nbsp;&nbsp;[Quick Tree Generator](/extensions/Quick_Tree_Generator)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Simple Pine Generator](/extensions/Simple_Pine_Generator)  
+&nbsp;&nbsp;&nbsp;&nbsp;[SPS Tree Generator](/extensions/SPS_Tree_Generator)  
+****  
+**Utility**  
+&nbsp;&nbsp;&nbsp;&nbsp;[The Babylon.js Sandbox and Editor](/tutorials/The_Babylon.js_Sandbox_and_Editor)  
+****  
+**Videos**  
+&nbsp;&nbsp;&nbsp;&nbsp;[3D on the Web Understanding the Basics](/tutorials/01._3D_on_the_Web_Understanding_the_Basics)  
+&nbsp;&nbsp;&nbsp;&nbsp;[3D Programming with WebGL and Babylon.js for Beginners](/tutorials/Zenva_course)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Babylon.js Advanced Features](/tutorials/07._Babylon.js_Advanced_Features)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Game Pipeline Integration with Babylon.js](/tutorials/05._Game_Pipeline_Integration_with_Babylon.js)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Loading Assets](/tutorials/06._Loading_Assets)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Special Effects](/tutorials/08._Special_Effects)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Understanding Materials and Inputs](/tutorials/04._Understanding_Materials_and_Inputs)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Using Babylon.js for Beginners](/tutorials/03._Using_Babylon.js_for_Beginners)  
+&nbsp;&nbsp;&nbsp;&nbsp;[Video courses](/tutorials/Video_courses)  
+&nbsp;&nbsp;&nbsp;&nbsp;[WebGL Basics](/tutorials/02._WebGL_Basics)  

--- a/data/statics.json
+++ b/data/statics.json
@@ -769,6 +769,18 @@
       "desc": "All overviews."
     },
     {
+      "title": "Maps",
+      "name": "Maps",
+      "img": "img/tutorials/All.png",
+      "desc": "Documentation Category Map",
+      "files": [
+        {
+          "title": "Documentation Category Map",
+          "filename": "Documentation_Category_Map"
+        }
+      ]
+    }, 
+    {
       "title": "Standard",
       "name": "Standard",
       "img": "img/tutorials/All.png",

--- a/views/index.jade
+++ b/views/index.jade
@@ -19,7 +19,8 @@ include includes/banner.jade
                 | Nothing needs to be installed on your computer to develop programs with
                 | BabylonJS. Nothing needs to be installed by the client to run your program.
                 | You can see this excess of simplicity in our <a href="#getting-started">Getting
-                | Started tutorial</a> just below!
+                | Started tutorial</a> just below! Then find out more and get an overview
+                | of possibilities by checking out the <a href = "overviews/Documentation_Category_Map"> documentation map</a>.
         .bjs-component
             h1 WebGL
             p


### PR DESCRIPTION
Have added a page that splits the documentation pages into categories which acts like an index. This is in overviews - Maps. Have cheekily added a link to this on the index page (index.jade) in the Easy Setup section, as it was the best way I thought of letting visitors to the site know of its existence. If this is a problem then please delete the extra text. I did think of putting the link in the footer as Index but thought that was probably a step too far and I was not clear how to handle i.fa.fa etc correctly so didn't do it.
