### PR TITLE
Added doc about invertUV + fix/complete some missing doc

### DIFF
--- a/content/overviews/Standard/Solid_Particle_System.md
+++ b/content/overviews/Standard/Solid_Particle_System.md
@@ -429,7 +429,7 @@ function setParticles() {
 Example : http://www.babylonjs-playground.com/#1X7SUN#5  
 or dancing worms : http://www.babylonjs-playground.com/#1X7SUN#7  
 
-###Pickable Particles
+### Pickable Particles
 You can set your particles as pickable with the parameter `isPickable` (default _false_) when creating your SPS :
 ```javascript
 var SPS = new BABYLON.SolidParticleSystem('SPS', scene, {isPickable: true});
@@ -462,7 +462,7 @@ The SPS pickability is directly related to the size of its bounding box (please 
 Pickable particle example (no SPS update in the render loop) : http://www.babylonjs-playground.com/#2FPT1A#41  
 Pickable particle example (particle rotation) : http://www.babylonjs-playground.com/#2FPT1A#14  
 
-###Digest a Mesh
+### Digest a Mesh
 There is another way than adding shapes of meshes used as models to populate the SPS : you can directly "digest" a mesh.  
 To digest a mesh means that the SPS will decompose this mesh geometry and use all its facets to generate the particles. So, by default, a digested mesh generates as many particles as the mesh number of facets.  
 ```javascript
@@ -501,7 +501,7 @@ SPS.buildMesh();
 ```
 Example (click on the torus knot) : http://www.babylonjs-playground.com/#HDHQN  
 
-###SPS Visibility
+### SPS Visibility
 To render the meshes on the screen, BJS uses their bounding box (BBox) : if the BBox is in the frustum, then the mesh is selected to be rendered on the screen. This method is really performant as it avoids to make the GPU compute things that wouldn't be visible. The BBox of each mesh is recomputed when its World Martix is updated.    
 When you create a SPS, unless you use the `positionFunction` at creation time, all its particles are set by default at the position (0, 0, 0). So the size of the SPS mesh is initially the size of its biggest particle, so it is for its BBox.  
 If you animate your particles without updating the SPS mesh World Matrix (ex : the whole SPS doesn't move, rotate or scale), its BBox may keep far more little than the current space occupied by the moving particles. So, if this little BBox gets out of the screen (cam rotation for instance), the whole SPS can then disappear at once !  
@@ -529,7 +529,7 @@ If the SPS keeps within some known limits, then it is better to use `SPS.setVisi
 At last, if you still need pickability or variable visibility, and don't know how your SPS will evolve, then you might set `SPS.computeBoundingBox` to true.  
 
 
-###Garbage Collector Concerns  
+### Garbage Collector Concerns  
 In Javascript, the Garbage Collector is usually your friend : it takes care about cleaning up all the not any longer needed variables you could have declared and thus it sets the memory free.  
 However, it can sometimes become an awkward friend because it can start its cleaning just while you are displaying a very smooth animation, so it takes the CPU for itself and leaves to you only those nice lags on the screen.  
 So the best to do to avoid this GC unpredictable behavior is to keep as low as possible the creation of temporary objects or variables in the render loop.  
@@ -566,7 +566,7 @@ SPS.vars.myString = "foo"; // just keep setting string values to myString afterw
 Example : From this [article](http://gamedevelopment.tutsplus.com/tutorials/the-three-simple-rules-of-flocking-behaviors-alignment-cohesion-and-separation--gamedev-3444), here is an implementation of a simple particle IA called "flocking" what a behavior of association, then cohesion and separation. This example uses `SPS.vars` to allocate the memory used for results only once instead of in-function temporary variables.     
 http://www.babylonjs-playground.com/#2FPT1A#35   
 
-###Rebuild the mesh
+### Rebuild the mesh
 if a mesh, changed at creation time with `positionFunction` or `vertexFunction` has been then modified with `setParticles()`, it can be rebuild by reapplying the internally stored `positionFunction` or `vertexFunction` functions.  
 Note that only the function are stored, not their results. This means that if one of your function produces different results each call (using `Math.random()` for instance), you won't get back the same SPS mesh shape but another computed shape.  
 ```javascript

--- a/content/tutorials/01_Play_Pen/CreateBox_Per_Face_Textures_And_Colors.md
+++ b/content/tutorials/01_Play_Pen/CreateBox_Per_Face_Textures_And_Colors.md
@@ -91,11 +91,14 @@ Forget about the _for{}_ loop, just initialize our _faceUV_ array and set only _
   var faceUV = new Array(6);
   faceUV[4] = new BABYLON.Vector4(0, 0, 1 / hSpriteNb, 1 / vSpriteNb);
 ```
-Only two lines of code only and that's all : http://www.babylonjs-playground.com#1V3CAT# 25  
+Only two lines of code and that's all : http://www.babylonjs-playground.com#1V3CAT#25  
+<br/>
+As we notice it, the default value `(0, 0, 1, 1)` is then applied to the other faces.   
+So if we need, for instance, to display the texture onto one face only, we could then set all the faceUV to `(0, 0, 0, 0)` just before : http://www.babylonjs-playground.com/#1V3CAT#145  
 <br/>
 <br/>
 We could also want to apply two different images from the same texture file onto two different meshes.  
-Nothing easier : http://www.babylonjs-playground.com#1V3CAT# 26    
+Nothing easier : http://www.babylonjs-playground.com#1V3CAT#26    
 Two boxes, two images, but only one texture !
 <br/>
 <br/>
@@ -124,7 +127,7 @@ Then pass this array to the `CreateBox()` method with the new `faceColors` param
 ```
 Simple, isn't it ?  http://www.babylonjs-playground.com#1V3CAT#14  
 
-These colors are BJS Color4-class values. The Color4 alpha values become active if we set `hasVertexAlpha = true` : http://www.babylonjs-playground.com#1V3CAT# 27  
+These colors are BJS Color4-class values. The Color4 alpha values become active if we set `hasVertexAlpha = true` : http://www.babylonjs-playground.com#1V3CAT#27  
 
 We can even combine the vertex colors with a colored material, blue here :  http://www.babylonjs-playground.com#1V3CAT#15  
 

--- a/content/tutorials/01_Play_Pen/Mesh_CreateXXX_Methods_With_Options_Parameter.md
+++ b/content/tutorials/01_Play_Pen/Mesh_CreateXXX_Methods_With_Options_Parameter.md
@@ -301,6 +301,8 @@ On update, you must set the _points_ and _instance_ properties.
 
 Example :
 ```javascript
+var lines = BABYLON.MeshBuilder.CreateLines("lines", {points: myArray}, scene);
+// creates an instance
 lines = BABYLON.MeshBuilder.CreateLines("lines", {points: myArray, instance: lines});
 // updates the existing instance of lines : no need for the parameter scene here
 ```
@@ -318,7 +320,9 @@ On update, you must set the _points_ and _instance_ properties.
 
 Example :
 ```javascript
-dashedLines = BABYLON.MeshBuilder.CreateDashedLines("dl", {points: myArray, instance: dashedLines});
+var dashedLines = BABYLON.MeshBuilder.CreateDashedLines("dl", {points: myArray}, scene);
+// creates an instance
+dashedLines = BABYLON.MeshBuilder.CreateDashedLines(null, {points: myArray, instance: dashedLines});
 // updates the existing instance of dashedLines : no need for the parameter scene here
 ```
 Properties :
@@ -338,7 +342,9 @@ On update, you must set the _lines_ and _instance_ properties.
 
 Example :
 ```javascript
-lineSystem = BABYLON.MeshBuilder.CreateLineSystem("lineSystem", {lines: myArray, instance: lineSystem});
+var lineSystem = BABYLON.MeshBuilder.CreateLineSystem("lineSystem", {lines: myArray}, scene);
+// creates an instance
+lineSystem = BABYLON.MeshBuilder.CreateLineSystem(null, {lines: myArray, instance: lineSystem});
 // updates the existing instance of lineSystem : no need for the parameter scene here
 ```
 Properties :
@@ -355,7 +361,9 @@ On update, you must set the _pathArray_ and _instance_ properties.
 
 Example :
 ```javascript
-ribbon = BABYLON.MeshBuilder.CreateRibbon("ribbon", {pathArray: myPaths, instance: ribbon});
+var ribbon = BABYLON.MeshBuilder.CreateRibbon("ribbon", {pathArray: myPaths}, scene);
+// creates an instance
+ribbon = BABYLON.MeshBuilder.CreateRibbon(null, {pathArray: myPaths, instance: ribbon});
 // updates the existing instance of ribbon : no need for the parameter scene
 ```
 Properties :
@@ -369,6 +377,7 @@ offset|_(number)_  used if the pathArray has one path only|half the path length
 updatable|_(boolean)_ true if the mesh is updatable|false
 sideOrientation|_(number)_ side orientation|DEFAULTSIDE
 instance|_(LineMesh)_ an instance of a ribbon to be updated|null
+invertUV|_(boolean)_ to swap the U and V coordinates at geometry construction time (texture rotation of 90°)|false
 
 #### Tube
 You must set at least the _path_ property.
@@ -376,7 +385,9 @@ On update, you must set the _path_ and _instance_ properties and you can set the
 
 Example :
 ```javascript
-tube = BABYLON.MeshBuilder.CreateTube("tube", {path: myPath, instance: tube});
+var tube = BABYLON.MeshBuilder.CreateTube("tube", {path: myPath}, scene);
+// creates an instance
+tube = BABYLON.MeshBuilder.CreateTube(null, {path: myPath, instance: tube});
 // updates the existing instance of tube : no need for the parameter scene
 ```
 Properties :
@@ -392,6 +403,7 @@ arc|_(number)_ ratio of the tube circumference between 0 and 1|1
 updatable|_(boolean)_ true if the mesh is updatable|false
 sideOrientation|_(number)_ side orientation|DEFAULTSIDE
 instance|_(LineMesh)_ an instance of a tube to be updated|null
+invertUV|_(boolean)_ to swap the U and V coordinates at geometry construction time (texture rotation of 90°)|false
 
 #### Extruded Shapes
 You must set at least the _shape_ and _path_ properties.
@@ -399,7 +411,9 @@ On update, you must set the _shape_, _path_ and _instance_ properties and you ca
 
 Example :
 ```javascript
-extruded = BABYLON.MeshBuilder.ExtrudeShape("ext", {shape: myShape, path: myPath, scale: newScale, rotation: newRotation instance: extruded});
+var extruded = BABYLON.MeshBuilder.ExtrudeShape("ext", {shape: myShape, path: myPath}, scene);
+// creates an instance
+extruded = BABYLON.MeshBuilder.ExtrudeShape(null, {shape: myShape, path: myPath, scale: newScale, rotation: newRotation, instance: extruded});
 // updates the existing instance of extruded : no need for the parameter scene
 ```
 Properties :
@@ -414,6 +428,7 @@ cap|_(number)_ extrusion cap : NO_CAP, CAP_START, CAP_END, CAP_ALL|NO_CAP
 updatable|_(boolean)_ true if the mesh is updatable|false
 sideOrientation|_(number)_ side orientation|DEFAULTSIDE
 instance|_(LineMesh)_ an instance of an extruded shape to be updated|null
+invertUV|_(boolean)_ to swap the U and V coordinates at geometry construction time (texture rotation of 90°)|false
 
 #### Custom Extruded Shapes
 You must set at least the _shape_ and _path_ properties.
@@ -421,7 +436,9 @@ On update, you must set the _shape_, _path_ and _instance_ properties and you ca
 
 Example :
 ```javascript
-extruded = BABYLON.MeshBuilder.ExtrudeShapeCustom("ext", {shape: myShape, path: myPath, scaleFunction: myScaleF, rotationFunction: myRotF instance: extruded});
+var extruded = BABYLON.MeshBuilder.ExtrudeShapeCustom("ext", {shape: myShape, path: myPath}, scene);
+// creates an instance
+extruded = BABYLON.MeshBuilder.ExtrudeShapeCustom(null, {shape: myShape, path: myPath, scaleFunction: myScaleF, rotationFunction: myRotF, instance: extruded});
 // updates the existing instance of extruded : no need for the parameter scene
 ```
 Properties :
@@ -438,6 +455,7 @@ cap|_(number)_ extrusion cap : NO_CAP, CAP_START, CAP_END, CAP_ALL|NO_CAP
 updatable|_(boolean)_ true if the mesh is updatable|false
 sideOrientation|_(number)_ side orientation|DEFAULTSIDE
 instance|_(LineMesh)_ an instance of an extruded shape to be updated|null
+invertUV|_(boolean)_ to swap the U and V coordinates at geometry construction time (texture rotation of 90°)|false
 
 #### Lathe
 You must set at least the _shape_ property.
@@ -458,8 +476,7 @@ cap|_(number)_ tube cap : NO_CAP, CAP_START, CAP_END, CAP_ALL|NO_CAP
 closed|_(boolean)_ to open/close the lathe circumference, should be set to `false` when used with `arc`|true
 updatable|_(boolean)_ true if the mesh is updatable|false
 sideOrientation|_(number)_ side orientation|DEFAULTSIDE
-
-
+invertUV|_(boolean)_ to swap the U and V coordinates at geometry construction time (texture rotation of 90°)|false
 
 
 <br/>


### PR DESCRIPTION
The new `invertUV` parameter is documented in `CreateXXX()` doc
+
- added better snippet about how to create then update each parametric shapes
- fix some broken PG links in per face color/texture doc
- added the way to texture only one face (idea from a forum answer)
