### PR TITLE
Add build step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Before beginning, please be sure to have these packages installed:
 ## Run a local copy of the documentation
  * ```git clone https://github.com/BabylonJS/Documentation.git && cd Documentation```Clone this repository
  * ```npm install``` to install all dependencies
+ * ```grunt build``` to build documentation
  * ```grunt serve``` runs the server and open a tab in your default browser
 
 ## Useful command


### PR DESCRIPTION
When attempting to run documentation locally, the data folder is not available without running 'grunt build'. This PR adds the build step to the setup instructions.

```
Running "open:local" (open) task
                 ^

Error: ENOENT: no such file or directory, scandir 'data/search'
    at Error (native)
    at Object.fs.readdirSync (fs.js:856:18)
    at module.exports (/Users/redacted/Projects/Documentation/scripts/loadIndexes.js:18:18)
    at Object.<anonymous> (/Users/redacted/Projects/Documentation/app.js:29:54)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
```
