### PR TITLE
Correct programming terminology

### DIFF
--- a/content/generals/General/Approved_Naming_Conventions.md
+++ b/content/generals/General/Approved_Naming_Conventions.md
@@ -8,7 +8,7 @@ If you want to contribute to babylon.js (What an *excellent* idea!), you should 
 - Private variables are named starting with _ : ```_myVariable```
 - Camel casing is used for non static properties/functions/variables: ```var myUberUsefulVariable```
 - Pascal casing must be used for "static" functions: ```BABYLON.Vector3.Project```
-- Braces ({}) must be used for every loop even when there is only one line:
+- Braces ({}) must be used for every block, even when there is only one line:
 ```
 if (condition) {
     this.doSomething();


### PR DESCRIPTION
Changed "loop" to "block" because braces surround blocks in general, not specifically loops. An if statement encloses a block and is not a loop.