### PR TITLE
Change the Typescript example to be object oriented

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -101,59 +101,38 @@ include includes/banner.jade
         p.js.
             We will now write the necessary javascript code to run our demonstration. To begin with, insert at the end
             of your &lt;body&gt;:
-        p.ts.
-            We will now write the necessary typescript code to run our demonstration. To begin with, create a new file game.ts :
-        pre
+        pre.js
             code.html.js.
                 &lt;script&gt;
                     window.addEventListener('DOMContentLoaded', function() {
                         // your code here
                     });
                 &lt;/script&gt;
-            code.javascript.ts.
-                window.addEventListener('DOMContentLoaded', () =&gt; {
-                    // your code here
-                });
-        p.ts.
-            Don't forget to add the reference to <code>game.js</code>, which will be generated from <code>game.ts</code>, to your index.html :
-        pre.ts
-            code.html.
-                &lt;!DOCTYPE html&gt;
-                &lt;html&gt;
-                &lt;head&gt;
-                    &lt;script src="game.js"&gt;&lt;/script&gt;
-                &lt;/head&gt;
-                &lt;/html&gt;
-        p.
+        p.js.
             As you can see, we wrap the javascript code inside of a <code>DOMContentLoaded</code> event handler, to be sure
             that the whole DOM is loaded before doing anything else. The code we'll write after this point is to be placed
             inside of this wrapper.
-        p.
+        p.js.
             The code we'll show you implements the very basics of every BabylonJS program, meaning the creation of a
             scene, and the insertion and display of meshes (here, two basic shapes: a sphere and a ground plane). We'll
             go through it step by step.
-        p.
+        p.js.
             The first step is to get the reference of the canvas element from our HTML document:
-        pre
+        pre.js
             code.javascript.js.
                 var canvas = document.getElementById('renderCanvas');
-            code.javascript.ts.
-                var canvas = &lt;HTMLCanvasElement&gt;document.getElementById('renderCanvas');
-        p.
+        p.js.
             Then, load the Babylon 3D engine:
-        pre
+        pre.js
             code.javascript.js.
                 var engine = new BABYLON.Engine(canvas, true);
-            code.javascript.ts.
-                /// &lt;reference path="babylon.2.3.d.ts" /&gt;
-                var engine = new BABYLON.Engine(canvas, true);
-        P.
+        p.js.
             After that, we create our scene. In order to keep your program compatible with the Babylon.js Playground,
             we recommend that you insert a "createScene" function at this point. Beside generating a Babylon Scene
             Object, <code>createScene()</code> is where you will add your basic scene requirements: a camera, a light,
             and two basic meshes (a sphere and a ground plane).
-        pre
-            code.javascript.
+        pre.js
+            code.javascript.js.
                 var createScene = function() {
                     // create a basic BJS Scene object
                     var scene = new BABYLON.Scene(engine);
@@ -182,34 +161,138 @@ include includes/banner.jade
                     // return the created scene
                     return scene;
                 }
-        p.
+        p.js.
             Now that our <code>createScene()</code> function is ready, we need to call it:
-        pre
-            code.javascript.
+        pre.js
+            code.javascript.js.
                 var scene = createScene();
-        p.
+        p.js.
             The next three javascript lines are very important, as they register a render loop to repeatedly render the
             scene on the canvas:
-        pre
+        pre.js
             code.javascript.js.
                 engine.runRenderLoop(function() {
                     scene.render();
                 });
-            code.javascript.ts.
-                engine.runRenderLoop(() =&gt; {
-                    scene.render();
-                });
-        p.
+        p.js.
             Lastly, you should implement a little canvas/window resize event handler, like this:
-        pre
+        pre.js
             code.javascript.js.
                 window.addEventListener('resize', function() {
                     engine.resize();
                 });
+        p.ts.
+            We will now write the necessary Typescript code to run our demonstration.
+            To begin with, create a new file <code>game.ts</code> with <code>Game</code>
+            class with a <code>constructor</code> and two methods, <code>createScene<c/ode>
+            and <code>animate</code>. And add a Event Listener for <code>DOMContentLoaded</code>
+            which will instantiate the <code>Game</code>, create the scene and start the animation :
+        pre.ts
             code.javascript.ts.
-                window.addEventListener('resize', () =&gt; {
-                    engine.resize();
+                class Game {
+                  constructor(canvasElement : string) {
+                  }
+
+                  createScene() : void {
+                  }
+
+                  animate() : void {
+                  }
+                }
+
+                window.addEventListener('DOMContentLoaded', () => {
+                  // Create the game using the 'renderCanvas'
+                  let game = new Game('renderCanvas');
+
+                  // Create the scene
+                  game.createScene();
+
+                  // start animation
+                  game.animate();
                 });
+        p.ts.
+            Next we'll add the instance variables needed for our game. These will
+            all be private so, following the Babylon js <a href="http://doc.babylonjs.com/generals/Approved_Naming_Conventions">
+            coding guidelines</a>, they'll all begin an underscore :
+        pre.ts.
+            code.javascript.ts.
+                class Game {
+                    private _canvas: HTMLCanvasElement;
+                    private _engine: BABYLON.Engine;
+                    private _scene: BABYLON.Scene;
+                    private _camera: BABYLON.FreeCamera;
+                    private _light: BABYLON.Light;
+
+                    ...
+                }
+        p.ts.
+            Now implement the <code>constructor</code>, its passed the name of the canvas element
+            and constructors have no return value. The code uses the <code>canvasElement</code>
+            parameter to create the canvas and then creates the engine :
+        pre.ts.
+            constructor(canvasElement : string) {
+              // Create canvas and engine
+              this._canvas = <HTMLCanvasElement>document.getElementById(canvasElement);
+              this._engine = new BABYLON.Engine(this._canvas, true);
+            }
+        p.ts.
+            Then implement <code>createScene</code>, which takes no parameters and returns nothing
+            hence its type is <code>void</code>. The code comments detail its actions.
+        pre.ts.
+            createScene() : void {
+               // create a basic BJS Scene object
+               this._scene = new BABYLON.Scene(this._engine);
+
+               // create a FreeCamera, and set its position to (x:0, y:5, z:-10)
+               this._camera = new BABYLON.FreeCamera('camera1', new BABYLON.Vector3(0, 5,-10), this._scene);
+
+               // target the camera to scene origin
+               this._camera.setTarget(BABYLON.Vector3.Zero());
+
+               // attach the camera to the canvas
+               this._camera.attachControl(this._canvas, false);
+
+               // create a basic light, aiming 0,1,0 - meaning, to the sky
+               this._light = new BABYLON.HemisphericLight('light1', new BABYLON.Vector3(0,1,0), this._scene);
+
+               // create a built-in "sphere" shape; with 16 segments and diameter of 2
+               let sphere = BABYLON.MeshBuilder.CreateSphere('sphere1',
+                                        {segments: 16, diameter: 2}, this._scene);
+
+               // move the sphere upward 1/2 of its height
+               sphere.position.y = 1;
+
+               // create a built-in "ground" shape
+               let ground = BABYLON.MeshBuilder.CreateGround('ground1',
+                                        {width: 6, height: 6, subdivisions: 2}, this._scene);
+            }
+        p.ts.
+            Next we'll implement <code>animate</code>, which also takes no
+            parameters and returns nothing. This routine starts the rendering
+            loop and adds the resize Event Listener :
+        pre.ts.
+            animate() : void {
+              // run the render loop
+              this._engine.runRenderLoop(() => {
+                  this._scene.render();
+              });
+
+              // the canvas/window resize event handler
+              window.addEventListener('resize', () => {
+                  this._engine.resize();
+              });
+            }
+        p.ts.
+            Finally, save the <code>game.ts</code> file and add the reference to <code>game.js</code>,
+            which will be generated from <code>game.ts</code>, to your index.html :
+        pre.ts.
+            code.html.
+                &lt;!DOCTYPE html&gt;
+                &lt;html&gt;
+                &lt;head&gt;
+                    &lt;script src="game.js"&gt;&lt;/script&gt;
+                &lt;/head&gt;
+                &lt;/html&gt;
         p.ts.
             Your Awesome Project directory should now contain:
         pre.ts
@@ -357,58 +440,71 @@ include includes/banner.jade
                 &lt;/html&gt;
         p.ts.
             Then, feel free to copy-paste the following code in your <code>game.ts</code> file:
-        pre.ts
-            code.javascript.
-                window.addEventListener('DOMContentLoaded', () =&gt; {
-                    // get the canvas DOM element
-                    var canvas = &lt;HTMLCanvasElement&gt;document.getElementById('renderCanvas');
+        pre.ts.
+            class Game {
+              private _canvas: HTMLCanvasElement;
+              private _engine: BABYLON.Engine;
+              private _scene: BABYLON.Scene;
+              private _camera: BABYLON.FreeCamera;
+              private _light: BABYLON.Light;
 
-                    // load the 3D engine
-                    var engine = new BABYLON.Engine(canvas, true);
+              constructor(canvasElement : string) {
+                // Create canvas and engine
+                this._canvas = <HTMLCanvasElement>document.getElementById(canvasElement);
+                this._engine = new BABYLON.Engine(this._canvas, true);
+              }
 
-                    // createScene function that creates and return the scene
-                    var createScene = function() {
-                        // create a basic BJS Scene object
-                        var scene = new BABYLON.Scene(engine);
+              createScene() : void {
+                  // create a basic BJS Scene object
+                  this._scene = new BABYLON.Scene(this._engine);
 
-                        // create a FreeCamera, and set its position to (x:0, y:5, z:-10)
-                        var camera = new BABYLON.FreeCamera('camera1', new BABYLON.Vector3(0, 5,-10), scene);
+                  // create a FreeCamera, and set its position to (x:0, y:5, z:-10)
+                  this._camera = new BABYLON.FreeCamera('camera1', new BABYLON.Vector3(0, 5,-10), this._scene);
 
-                        // target the camera to scene origin
-                        camera.setTarget(BABYLON.Vector3.Zero());
+                  // target the camera to scene origin
+                  this._camera.setTarget(BABYLON.Vector3.Zero());
 
-                        // attach the camera to the canvas
-                        camera.attachControl(canvas, false);
+                  // attach the camera to the canvas
+                  this._camera.attachControl(this._canvas, false);
 
-                        // create a basic light, aiming 0,1,0 - meaning, to the sky
-                        var light = new BABYLON.HemisphericLight('light1', new BABYLON.Vector3(0,1,0), scene);
+                  // create a basic light, aiming 0,1,0 - meaning, to the sky
+                  this._light = new BABYLON.HemisphericLight('light1', new BABYLON.Vector3(0,1,0), this._scene);
 
-                        // create a built-in "sphere" shape; its constructor takes 5 params: name, width, depth, subdivisions, scene
-                        var sphere = BABYLON.Mesh.CreateSphere('sphere1', 16, 2, scene);
+                  // create a built-in "sphere" shape; with 16 segments and diameter of 2
+                  let sphere = BABYLON.MeshBuilder.CreateSphere('sphere1',
+                                        {segments: 16, diameter: 2}, this._scene);
 
-                        // move the sphere upward 1/2 of its height
-                        sphere.position.y = 1;
+                  // move the sphere upward 1/2 of its height
+                  sphere.position.y = 1;
 
-                        // create a built-in "ground" shape; its constructor takes the same 5 params as the sphere's one
-                        var ground = BABYLON.Mesh.CreateGround('ground1', 6, 6, 2, scene);
+                  // create a built-in "ground" shape
+                  let ground = BABYLON.MeshBuilder.CreateGround('ground1',
+                                        {width: 6, height: 6, subdivisions: 2}, this._scene);
+              }
 
-                        // return the created scene
-                        return scene;
-                    }
-
-                    // call the createScene function
-                    var scene = createScene();
-
-                    // run the render loop
-                    engine.runRenderLoop(() =&gt; {
-                        scene.render();
-                    });
-
-                    // the canvas/window resize event handler
-                    window.addEventListener('resize', () =&gt; {
-                        engine.resize();
-                    });
+              animate() : void {
+                // run the render loop
+                this._engine.runRenderLoop(() => {
+                    this._scene.render();
                 });
+
+                // the canvas/window resize event handler
+                window.addEventListener('resize', () => {
+                    this._engine.resize();
+                });
+              }
+            }
+
+            window.addEventListener('DOMContentLoaded', () => {
+              // Create the game using the 'renderCanvas'
+              let game = new Game('renderCanvas');
+
+              // Create the scene
+              game.createScene();
+
+              // start animation
+              game.animate();
+            });
     // HIGHLIGHT JS
     script(src='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js')
     script(src='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/languages/javascript.min.js')


### PR DESCRIPTION
Previously the typescript and javascript example were interleaved, since
they are now quite different I've separated within the page. Hence the
greater number of lines changed than might be expected.