### PR TITLE
Playground search bug. [temp fix]

### DIFF
--- a/public/html/js/search_playground.js
+++ b/public/html/js/search_playground.js
@@ -9,7 +9,7 @@
         var query = getQueryVariable('q');
         var strQuery = decodeURIComponent(query).split('+').join(' ');
         var page = +(getQueryVariable('page')) || 0;
-        var max = +(getQueryVariable('max')) || 25;
+        var max = +(getQueryVariable('max')) || 24; // Weird bug with 25.
 
         if (!query) {
             //$('.searchplayground-content').append('<div class="searchHeader"><h2>No Query Found.</h2></div>');


### PR DESCRIPTION
Weird bug with pageSize 25 and some search terms like "appendScene", "boxify", "panmat"... . Work with 24, 26, and multiple of 25.