### PR TITLE
Issue correction : 3056

### DIFF
--- a/public/html/js/search_playground.js
+++ b/public/html/js/search_playground.js
@@ -470,6 +470,9 @@
 
                 // Size of the substring to extract
                 var size = 500;
+                var lastSpanIndex = originalText.lastIndexOf("</span>"); // Avoid to cut a span and end with weird html things.
+                if(lastSpanIndex > 500)
+                    size = lastSpanIndex + 8;
                 if (size + begIndex > originalText.length) {
                     size = originalText.length - begIndex;
                 }


### PR DESCRIPTION
https://github.com/BabylonJS/Babylon.js/issues/3056

<span></span> was cutted because of the 500 char limit on the preview.