### PR TITLE
Improve How_to_use_Actions.md page

### DIFF
--- a/content/How_To/events/How_to_use_Actions.md
+++ b/content/How_To/events/How_to_use_Actions.md
@@ -16,7 +16,15 @@ mesh.actionManager = new BABYLON.ActionManager(scene);
 Once the ActionManager is created, you can start registering actions:
 
 ```javascript
-mesh.actionManager.registerAction(new BABYLON.InterpolateValueAction(BABYLON.ActionManager.OnPickTrigger, light, "diffuse", BABYLON.Color3.Black(), 1000));
+mesh.actionManager.registerAction(
+    new BABYLON.InterpolateValueAction(
+        BABYLON.ActionManager.OnPickTrigger,
+        light,
+        'diffuse',
+        BABYLON.Color3.Black(),
+        1000
+    )
+);
 ```
 
 For instance this action will animate the `light.diffuse` property to black in 1000ms when the user picks the mesh.
@@ -24,26 +32,55 @@ For instance this action will animate the `light.diffuse` property to black in 1
 You can also chain actions:
 
 ```javascript
-mesh.actionManager.registerAction(new BABYLON.InterpolateValueAction(BABYLON.ActionManager.OnPickTrigger, light, "diffuse", BABYLON.Color3.Black(), 1000)).then(new BABYLON.SetValueAction(BABYLON.ActionManager.NothingTrigger, mesh.material, "wireframe", false));
+mesh.actionManager
+    .registerAction(
+        new BABYLON.InterpolateValueAction(
+            BABYLON.ActionManager.OnPickTrigger,
+            light,
+            'diffuse',
+            BABYLON.Color3.Black(),
+            1000
+        )
+    )
+    .then(
+        new BABYLON.SetValueAction(
+            BABYLON.ActionManager.NothingTrigger,
+            mesh.material,
+            'wireframe',
+            false
+        )
+    );
 ```
 
-In this case, the first click will animate the `light.diffuse` property, the second click will set `mesh.material` to false. The third one will start again and will animate the `light.diffuse` property and so on...
+In this case, the first click will animate the `light.diffuse` property, the second click will set `mesh.material` to false.
+The third one will start again and will animate the `light.diffuse` property and so on...
 
 Finally, you can add a condition to your actions. In this case, actions are launched when the trigger is fired if the condition is true:
 
 ```javascript
-var condition1 = new BABYLON.PredicateCondition(sphere.actionManager, function () {
-    return light1.diffuse.equals(BABYLON.Color3.Red());
-});
-sphere.actionManager.registerAction(new BABYLON.InterpolateValueAction(BABYLON.ActionManager.OnPickTrigger, camera, "alpha", 0, 500, condition1));
+mesh.actionManager.registerAction(
+    new BABYLON.InterpolateValueAction(
+        BABYLON.ActionManager.OnPickTrigger,
+        camera,
+        'alpha',
+        0,
+        500,
+        new BABYLON.PredicateCondition(
+            mesh.actionManager,
+            function () {
+                return light.diffuse.equals(BABYLON.Color3.Red());
+            }
+        )
+    )
+);
 ```
 
-In this example, the `camera.alpha` property will be animated to 0 in 500ms when the user clicks the sphere only if the `light1.diffuse` property is equal to red.
+In this example, the `camera.alpha` property will be animated to 0 in 500ms when the user clicks the mesh only if the `light.diffuse` property is equal to red.
 
 ## Triggers
-Currently, 12 different triggers are supported:
+Currently, there are 17 different triggers available for meshes, and three for scenes.
 
-The following list defines triggers associated with meshes:
+The triggers available for meshes are:
 
 * `BABYLON.ActionManager.NothingTrigger`: Never raised. Used for sub-actions with `action.then` function.
 * `BABYLON.ActionManager.OnPickTrigger`: Raised when the user touches/clicks on a mesh.
@@ -57,144 +94,147 @@ The following list defines triggers associated with meshes:
 * `BABYLON.ActionManager.OnLongPressTrigger`: Raised when the user touches/clicks up on a mesh for a long period of time (defined by BABYLONActionManager.LongPressDelay). 
 * `BABYLON.ActionManager.OnPointerOverTrigger`: Raised when the pointer is over a mesh. Raised just once.
 * `BABYLON.ActionManager.OnPointerOutTrigger`: Raised when the pointer is no more over a mesh. Raised just once.
-* `BABYLON.ActionManager.OnIntersectionEnterTrigger`: Raised when the mesh is in intersection with another mesh. Raised just once.
-* `BABYLON.ActionManager.OnIntersectionExitTrigger`: Raised when the mesh is no more in intersection with another mesh. Raised just once.
 * `BABYLON.ActionManager.OnKeyDownTrigger`: Raised when a key is press.
 * `BABYLON.ActionManager.OnKeyUpTrigger`: Raised when a key is up
 * `BABYLON.ActionManager.OnEveryFrameTrigger`: ???
+* `BABYLON.ActionManager.OnIntersectionEnterTrigger`: Raised when the mesh is in intersection with a specific mesh. Raised just once.
+* `BABYLON.ActionManager.OnIntersectionExitTrigger`: Raised when the mesh is no more in intersection with a specific mesh. Raised just once. 
 
-For intersection triggers, you have to specify the "other" mesh with the following code:
-
-```javascript
-mesh.actionManager.registerAction(new BABYLON.SetValueAction({ trigger: BABYLON.ActionManager.OnIntersectionEnterTrigger, parameter: otherMesh }, mesh, "scaling", new BABYLON.Vector3(1.2, 1.2, 1.2)));
-```
-
-You can as well define if you want to use precise intersections:
+Note that the two intersection triggers require you specify a specific mesh, which can be done like so:
 
 ```javascript
-mesh.actionManager.registerAction(new BABYLON.SetValueAction({ trigger: BABYLON.ActionManager.OnIntersectionEnterTrigger, parameter: { mesh:otherMesh, usePreciseIntersection: true} }, mesh, "scaling", new BABYLON.Vector3(1.2, 1.2, 1.2)));
+mesh.actionManager.registerAction(
+    new BABYLON.SetValueAction(
+        {
+            trigger: BABYLON.ActionManager.OnIntersectionEnterTrigger, 
+            parameter: { 
+                mesh: otherMesh, 
+                usePreciseIntersection: true
+            }
+        }, 
+        mesh,
+        "scaling",
+        new BABYLON.Vector3(1.2, 1.2, 1.2)
+    )
+);
 ```
 
-The following list defines triggers associated with scene:
+Note the optional `usePreciseIntersection` property. If you don't want to use precise intersections, you can simply pass the mesh being targeted as the value of the parameter property:
+
+```javascript
+mesh.actionManager.registerAction(
+    new BABYLON.SetValueAction(
+        {
+            trigger: BABYLON.ActionManager.OnIntersectionEnterTrigger,
+            parameter: otherMesh
+        },
+        mesh,
+        'scaling',
+        new BABYLON.Vector3(1.2, 1.2, 1.2)
+    )
+);
+```
+The triggers available for scenses are:
 
 * `BABYLON.ActionManager.OnEveryFrameTrigger`: Raised once per frame.
 * `BABYLON.ActionManager.OnKeyDownTrigger`: Raised when a key is pressed.
 * `BABYLON.ActionManager.OnKeyUpTrigger`: Raised when a key is released.
 
-For OnKeyUpTrigger and OnKeyDownTrigger triggers, you can filter events based on a key, either in your code or with a parameter:
+Both the OnKeyUpTrigger and OnKeyDownTrigger triggers accept a string parameter value, which is compared to the event's `sourceEvent.key` value.
+This allows you to create key triggers that will only trigger on specific keys, like so:
 
 ```javascript
-scene.actionManager.registerAction(new BABYLON.ExecuteCodeAction(BABYLON.ActionManager.OnKeyUpTrigger, function (evt) {
-   if (evt.sourceEvent.key == "r") {
-       ...
-   }
-}));
-scene.actionManager.registerAction(new BABYLON.ExecuteCodeAction({ trigger: BABYLON.ActionManager.OnKeyUpTrigger, parameter: "r" },
-  function () {
-            ...
-}));
+scene.actionManager.registerAction(
+    new BABYLON.ExecuteCodeAction(
+        {
+            trigger: BABYLON.ActionManager.OnKeyUpTrigger,
+            parameter: 'r'
+        },
+        function () { console.log('r button was pressed'); }
+    )
+);
 ```
 
 ## Available Actions
-Most of the actions have a `propertyPath` property. This string defines the path to the property to affect with the action. You can use direct values like `position` or `diffuse`. But you can also provide complex paths like `position.x`
+Most of the actions have a `propertyPath` property. This string defines the path to the property to affect with the action. 
+You can use direct values like `position` or `diffuse`. But you can also provide complex paths like `position.x`
 
-* `BABYLON.SwitchBooleanAction`: Used to switch the current value of a boolean property:
-
-    `SwitchBooleanAction(trigger, target, propertyPath, condition)`
-
-* `BABYLON.SetValueAction`: Used to specify a direct value for a property:
-
-    `SetValueAction(trigger, target, propertyPath, value, condition)`
-
-* `BABYLON.IncrementValueAction`: Add a specified value to a number property:
-
-    `IncrementValueAction(trigger, target, propertyPath, value, condition)`
-
-* `BABYLON.PlayAnimationAction`: Launch an animation on a specified target:
-
-    `PlayAnimationAction(trigger, target, from, to, loop, condition)`
-
-* `BABYLON.StopAnimationAction`: Stop an animation on a specified target:
-
-    `StopAnimationAction(trigger, target, condition)`
-
-* `BABYLON.DoNothingAction`: Do nothing :)
-
-    `DoNothingAction(trigger, condition)`
-
-* `BABYLON.CombineAction`: This action is a container. You can use it to execute many actions simultaneously on the same trigger. The children property must be an array of actions:
-
-    `CombineAction(trigger, children, condition)`
-
-* `BABYLON.ExecuteCodeAction`: Execute your own code when the trigger is raised and the condition is true:
-
-    `ExecuteCodeAction(trigger, func, condition)`
-
-* `BABYLON.SetParentAction`: Used to define the parent of a node (camera, light, mesh):
-
-    `SetParentAction(trigger, target, parent, condition)`
-
-* `BABYLON.InterpolateValueAction`: This action creates an animation to interpolate the current value of a property to a given target. The following types are supported:
+* `BABYLON.SwitchBooleanAction(trigger, target, propertyPath, condition)`: Switchs a boolean property.
+* `BABYLON.SetValueAction(trigger, target, propertyPath, value, condition)`: Sets a direct value for a property.
+* `BABYLON.IncrementValueAction(trigger, target, propertyPath, value, condition)`: Adds a number to a number property.
+* `BABYLON.PlayAnimationAction(trigger, target, from, to, loop, condition)`: Plays an animation on a target.
+* `BABYLON.StopAnimationAction(trigger, target, condition)`: Stops any animation being played by the target.
+* `BABYLON.DoNothingAction(trigger, condition)`: Do nothing :)
+* `BABYLON.CombineAction(trigger, children[], condition)`: Executes multiple actions simultaneously. The children property must be an array of actions.
+* `BABYLON.ExecuteCodeAction(trigger, func, condition)`: Executes code.
+* `BABYLON.SetParentAction(trigger, target, parent, condition)`: Sets the parent of the target.
+* `BABYLON.PlaySoundAction(trigger, sound, condition)`: Plays a given sound.
+* `BABYLON.StopSoundAction(trigger, sound, condition)`: Stops a given sound
+* `BABYLON.InterpolateValueActiontrigger, target, propertyPath, value, duration, condition, stopOtherAnimations)`: Creates an animation to interpolate the current value of a property to a given target. The following types are supported:
    * `number`
    * `BABYLON.Color3`
    * `BABYLON.Vector3`
    * `BABYLON.Quaternion`
 
-    `InterpolateValueAction(trigger, target, propertyPath, value, duration, condition, stopOtherAnimations)`
-
-* `BABYLON.PlaySoundAction` and `BABYLON.StopSoundAction`: The "sound" parameter is the reference of the sound you created using `var sound = new BABYLON.Sound(...)`
-
-    `PlaySoundAction(trigger, sound, condition)`
-
-    `StopSoundAction(trigger, sound, condition)`
-
 ## Conditions
 There are three kinds of conditions:
 
-* `BABYLON.ValueCondition`: This condition is true when a given property is equal / greater / lesser / different from a specific value. The following operands are thus supported:
-   * `BABYLON.ValueCondition.IsEqual`
-   * `BABYLON.ValueCondition.IsDifferent`
-   * `BABYLON.ValueCondition.IsGreater`
-   * `BABYLON.ValueCondition.IsLesser`
-
-    `ValueCondition(actionManager, target, propertyPath, value, operator)`
-
-* `BABYLON.PredicateCondition`: This condition uses a predicate to determine its state:
-
-    `PredicateCondition(actionManager, predicate)`
-
-* `BABYLON.StateCondition`: This condition checks the ```state``` property of an object and compares it to given value:
-
-    `StateCondition(actionManager, target, value)`
+* `BABYLON.ValueCondition.IsEqual(actionManager, target, propertyPath, value, operator)`: true when the given property is equal to the given value.
+* `BABYLON.ValueCondition.IsDifferent(actionManager, target, propertyPath, value, operator)`: true when the given property is not equal to the given value.
+* `BABYLON.ValueCondition.IsGreater(actionManager, target, propertyPath, value, operator)`: true when the given property is greater then the given value.
+* `BABYLON.ValueCondition.IsLesser(actionManager, target, propertyPath, value, operator)`: true when the given property is less than the given value.
+* `BABYLON.PredicateCondition(actionManager, predicate)`: true when the given predicate function returns true
+* `BABYLON.StateCondition(actionManager, target, value)`: true when the ```state``` property of the target matches the given value.
 
 ## Experimenting with Actions
-So basically, let's imagine you want to almost hide a mesh when the user touches it.
-First of all you have to add a `BABYLON.ActionManager` on it:
+Imagine you want to almost hide a mesh when the user touches it.
+
+First, you'd add a  `BABYLON.ActionManager` to the mesh in question:
 
 ```javascript
 mesh.actionManager = new BABYLON.ActionManager(scene);
 ```
 
-Then you can create an action that will be associated with the `BABYLON.ActionManager.OnPickTrigger` trigger. This action will interpolate the ```mesh.visibility``` property to 0.2:
+Secondly, you'd register an action associated with the `BABYLON.ActionManager.OnPickTrigger` trigger.
+This action will interpolate the ```mesh.visibility``` property to 0.2.
 
 ```javascript
-var action = new BABYLON.InterpolateValueAction(BABYLON.ActionManager.OnPickTrigger, mesh, "visibility", 0.2, 1000);
-```
-
-Then add this action to the mesh:
-
-```javascript
-mesh.actionManager.registerAction(action);
+mesh.actionManager.registerAction(
+    new BABYLON.InterpolateValueAction(
+        BABYLON.ActionManager.OnPickTrigger,
+        mesh,
+        'visibility',
+        0.2,
+        1000
+    )
+);
 ```
 
 And you're done! Easy, right?
 
-You can also chain another action to restore the `mesh.visibility` property to default value:
+If after fading out the mesh, you wished it to fade back in, you'd do so by chaining an action
+to restore the `mesh.visibility` property to default value:
 
 ```javascript
-var action = new BABYLON.InterpolateValueAction(BABYLON.ActionManager.OnPickTrigger, mesh, "visibility", 0.2, 1000);
-var action2 = new BABYLON.InterpolateValueAction(BABYLON.ActionManager.OnPickTrigger, mesh, "visibility", 1.0, 1000);
-mesh.actionManager.registerAction(action).then(action2);
+mesh.actionManager
+        .registerAction(
+            new BABYLON.InterpolateValueAction(
+                BABYLON.ActionManager.OnPickTrigger,
+                mesh,
+                'visibility',
+                0.2,
+                1000
+            )
+        )
+        .then(
+            new BABYLON.InterpolateValueAction(
+                BABYLON.ActionManager.OnPickTrigger,
+                mesh,
+                'visibility',
+                1.0,
+                1000
+            )
+        );
 ```
 
 In this case, the first click will hide the button, the following click will restore it, and so on...


### PR DESCRIPTION
Applied new look to `How_to_use_Actions.md` as discussed in https://github.com/BabylonJS/Documentation/issues/753#issuecomment-356656102

Resulting from discussion on https://github.com/BabylonJS/Documentation/issues/753#issuecomment-356442444

@deltakosh I tried using tables, and I think they look good, except tables have some css rule that limits their width to 60%, when it should really be 100%.

Mesh Triggers Table with native css:
![ss 2018-01-11 at 09 18 26](https://user-images.githubusercontent.com/3151613/34793731-3f314270-f6b1-11e7-984b-f067a5b3272e.png)

Mesh Triggers Table with `width: 100%` (modified via Chrome Inspector):

![ss 2018-01-11 at 09 17 03](https://user-images.githubusercontent.com/3151613/34793768-5f1f9032-f6b1-11e7-9853-370107a5a843.png)

I've not looked into how the css stuff works, and don't want to just change the `.static-content table` since it would affect all good tables everywhere.

I'll likely revist the tables this weekend. You've welcome to either merge this PR now (and so I'd make another PR for the tables when I get around to doing them), or blocking it until tables commit. I have no major preference. 