### PR TITLE
Prevent crashing on some empty documentation blocks in code

### DIFF
--- a/scripts/helpers/builder/astHandler/typeStrategies/object.js
+++ b/scripts/helpers/builder/astHandler/typeStrategies/object.js
@@ -16,11 +16,13 @@ function objectToString(object) {
     var TypeManager = require('../typeManager');
 
     var objectTypeDescription = '{';
-    for (var index in object.typeMembers.members) {
-        var member = object.typeMembers.members[index];
-        objectTypeDescription += ' ' + TypeManager.getParameterString(member, true);
-        objectTypeDescription += ': ' + TypeManager.getReturnString(member);
-        if (index != object.typeMembers.members.length - 1) objectTypeDescription += ', ';
+    if(object.typeMembers) {
+        for (var index in object.typeMembers.members) {
+            var member = object.typeMembers.members[index];
+            objectTypeDescription += ' ' + TypeManager.getParameterString(member, true);
+            objectTypeDescription += ': ' + TypeManager.getReturnString(member);
+            if (index != object.typeMembers.members.length - 1) objectTypeDescription += ', ';
+        }
     }
     objectTypeDescription += ' }';
     object = objectTypeDescription;


### PR DESCRIPTION
The crash error is vague an unhelpful and prevents class documentation from finishing compiling. Suppressing it like this seems fine as the comment block was empty otherwise and allows for stubbing out work.