### PR TITLE
Fixing a minor spelling error on the Actions doc page.

### DIFF
--- a/content/How_To/events/How_to_use_Actions.md
+++ b/content/How_To/events/How_to_use_Actions.md
@@ -134,7 +134,7 @@ mesh.actionManager.registerAction(
     )
 );
 ```
-The triggers available for scenses are:
+The triggers available for scenes are:
 
 * `BABYLON.ActionManager.OnEveryFrameTrigger`: Raised once per frame.
 * `BABYLON.ActionManager.OnKeyDownTrigger`: Raised when a key is pressed.


### PR DESCRIPTION
Noticed this while browsing docs. 