### PR TITLE
fix(HowTo): The current Actions Conditions might misguide beginers.

### DIFF
--- a/content/How_To/events/How_to_use_Actions.md
+++ b/content/How_To/events/How_to_use_Actions.md
@@ -179,11 +179,12 @@ You can use direct values like `position` or `diffuse`. But you can also provide
 ## Conditions
 There are three kinds of conditions:
 
-* `BABYLON.ValueCondition.IsEqual(actionManager, target, propertyPath, value, operator)`: true when the given property is equal to the given value.
-* `BABYLON.ValueCondition.IsDifferent(actionManager, target, propertyPath, value, operator)`: true when the given property is not equal to the given value.
-* `BABYLON.ValueCondition.IsGreater(actionManager, target, propertyPath, value, operator)`: true when the given property is greater then the given value.
-* `BABYLON.ValueCondition.IsLesser(actionManager, target, propertyPath, value, operator)`: true when the given property is less than the given value.
-* `BABYLON.PredicateCondition(actionManager, predicate)`: true when the given predicate function returns true
+* `BABYLON.ValueCondition(actionManager, target, propertyPath, value, operator)`: true when the given property and value conform to the operator. The following operators are supported:
+   * `BABYLON.ValueCondition.IsEqual`
+   * `BABYLON.ValueCondition.IsDifferent`
+   * `BABYLON.ValueCondition.IsGreater`
+   * `BABYLON.ValueCondition.IsLesser`
+* `BABYLON.PredicateCondition(actionManager, predicate)`: true when the given predicate function returns true.
 * `BABYLON.StateCondition(actionManager, target, value)`: true when the ```state``` property of the target matches the given value.
 
 ## Experimenting with Actions


### PR DESCRIPTION
The parameter `operater` of condition is supposed to be a number, which means the ` BABYLON.ValueCondition.IsEqual` and others are number and not callable. The current doc might just make beginers take ` BABYLON.ValueCondition.IsEqual` as a condition but actually its just a number and works as operator parameter.