### PR TITLE
Update How_to_use_Actions.md

### DIFF
--- a/content/How_To/events/How_to_use_Actions.md
+++ b/content/How_To/events/How_to_use_Actions.md
@@ -91,7 +91,7 @@ The triggers available for meshes are:
 * `BABYLON.ActionManager.OnLeftPickTrigger`: Raised when the user touches/clicks on a mesh with left button.
 * `BABYLON.ActionManager.OnRightPickTrigger`: Raised when the user touches/clicks on a mesh with right button.
 * `BABYLON.ActionManager.OnCenterPickTrigger`: Raised when the user touches/clicks on a mesh with center button.
-* `BABYLON.ActionManager.OnLongPressTrigger`: Raised when the user touches/clicks up on a mesh for a long period of time (defined by BABYLONActionManager.LongPressDelay). 
+* `BABYLON.ActionManager.OnLongPressTrigger`: Raised when the user touches/clicks up on a mesh for a long period of time in milliseconds (defined by BABYLON.Scene.LongPressDelay). 
 * `BABYLON.ActionManager.OnPointerOverTrigger`: Raised when the pointer is over a mesh. Raised just once.
 * `BABYLON.ActionManager.OnPointerOutTrigger`: Raised when the pointer is no more over a mesh. Raised just once.
 * `BABYLON.ActionManager.OnKeyDownTrigger`: Raised when a key is press.


### PR DESCRIPTION
LongPressDelay is in the Scene class and not in ActionManager. I also add that it's a duration in milliseconds.