### PR TITLE
Added list of ordered Scene observables to observer docs

### DIFF
--- a/content/How_To/events/Observables.md
+++ b/content/How_To/events/Observables.md
@@ -6,22 +6,22 @@ PG_TITLE: How to Use Observables
 
 ## Introduction
 
-Babylon.js provides a lot of events (like scene.beforeRender) and before v2.4 there were not a unified way to handle them.
+Babylon.js provides a lot of events (like scene.beforeRender) and before v2.4 there was not a unified way to handle them.
 Starting with v2.4, we introduced (without breaking backward compatibility of course) a new pattern: the Obervables.
 
-There are two parts: the Observable and the Observer. The Observable is a property of an object which represent a given event (like beforeRender for instance). 
-Users that want to have their own piece of code running in response of such event will register an Observer to the adequate Observable. Then it's the duty of the Observable to execute the Observers, when appropriate.
+There are two parts: the Observable and the Observer. The Observable is a property of an object which represents a given event (like beforeRender for instance). 
+Users that want to have their own piece of code running in response to such event will register an Observer to the appropriate Observable. Then it's the duty of the Observable to execute the Observers, when appropriate.
 
 
 ## Observable
-The implementer uses it to create a property which will trigger all the registered observers.The Generic type T is used to communicate a given data type from the Observable to the Observer.
+The implementer uses it to create a property which will trigger all the registered observers. The Generic type T is used to communicate a given data type from the Observable to the Observer.
 
 You have the following method/properties:
 
 * add(): to add an Observer
 * remove(): to remove a previously registered Observer
 * removeCallback(): same as above but giving the callback instead of the Observer instance
-* notifyObservers(): used to notify all the registered Observers (with a little special feature I'll detail at the end of this post)
+* notifyObservers(): used to notify all the registered Observers (with a little special feature I'll detail further below)
 * hasObserver: a property that returns true if at least one Observer is registered
 * hasSpecificMask(mask): a function that returns true if at least one Observer is registered with this mask
 * clear() to remove all Observers
@@ -44,7 +44,7 @@ scene.onBeforeRenderObservable.add(function () {
 
 * [Playground Example Add](https://www.babylonjs-playground.com/#UP2O8#0)
 
-When you want to later remove your observer, you just need to store in during creation, then use it with remove:
+When you want to later remove your observer, you just need to store in _var_ during creation, then use it to remove:
 
 ```javascript
 var alpha = 0;
@@ -59,7 +59,7 @@ scene.onBeforeRenderObservable.remove(observer);
 * [Playground Example Add and Remove](https://www.babylonjs-playground.com/#UP2O8#1)
 
 ## Scene Object Observables
-The BabylonJS Scene Object has over 20 oberservables that 'fire' under various condtions. Most of them are checked EACH frame/render, and in a deterministic/predictable order or sequence.  Below is a list of Scene observables checked during each renderLoop... in the order they are checked:
+The BabylonJS Scene Object has over 20 observables that 'fire' under various conditions. Most of them are checked EACH frame/render, and in a deterministic/predictable order or sequence.  Below is a list of Scene observables checked during each renderLoop... in the order they are checked:
 
 - onBeforeAnimationsObservable
 - onAfterAnimationsObservable

--- a/content/How_To/events/Observables.md
+++ b/content/How_To/events/Observables.md
@@ -58,6 +58,26 @@ scene.onBeforeRenderObservable.remove(observer);
 ```
 * [Playground Example Add and Remove](https://www.babylonjs-playground.com/#UP2O8#1)
 
+## Scene Object Observables
+The BabylonJS Scene Object has over 20 oberservables that 'fire' under various condtions. Most of them are checked EACH frame/render, and in a deterministic/predictable order or sequence.  Below is a list of Scene observables checked during each renderLoop... in the order they are checked:
 
+- onBeforeAnimationsObservable
+- onAfterAnimationsObservable
+- onBeforePhysicsObservable
+- onAfterPhysicsObservable
+- onBeforeRenderObservable
+- onBeforeRenderTargetsRenderObservable
+- onAfterRenderTargetsRenderObservable
+- onBeforeCameraRenderObservable
+- onBeforeActiveMeshesEvaluationObservable
+- onAfterActiveMeshesEvaluationObservable
+- onBeforeParticlesRenderingObservable
+- onAfterParticlesRenderingObservable
+- onBeforeRenderTargetsRenderObservable
+- onAfterRenderTargetsRenderObservable
+- onBeforeDrawPhaseObservable
+- onAfterDrawPhaseObservable
+- onAfterCameraRenderObservable
+- onAfterRenderObservable
 
-
+The Scene Object also has observers: onReady, onDataLoaded, onDispose, but they do not happen within a rendering/frame.  Also, onBeforeStep, onAfterStep, which "are a special option when dealing with deterministic step", according to local experts.


### PR DESCRIPTION
Per http://www.html5gamedevs.com/topic/37628-scene-observables-firing-order/?do=findComment&comment=214905

Somebody once wrote "with a little special feature"...

I wonder if that special feature was ever included.  Was that referring to clone()... and it's ability to erase ALL registered observers?   *shrug*  Am I missing the "special feature"?  :)