### PR TITLE
help user find PBR page

### DIFF
--- a/data/statics.json
+++ b/data/statics.json
@@ -517,7 +517,7 @@
             "desc": "Environment Tutorials.",
             "files": [
                 {
-                    "title": "Start with Physically Based Rendering",
+                    "title": "Start with Physically Based Rendering (PBR)",
                     "level": 2,
                     "filename": "Physically_Based_Rendering"
                 },


### PR DESCRIPTION
It looks like a tiny detail, but each time I'm going to *How to* page, I make a search of `PBR` and never find it! So here the addition in the page title.