### PR TITLE
Some updates to height map docs

### DIFF
--- a/content/babylon101/babylon101/Height_Map.md
+++ b/content/babylon101/babylon101/Height_Map.md
@@ -16,10 +16,15 @@ _Final result_
   Those mountains are very easy to generate with Babylon.js, and with only a single function. But before we do that, we have to create a new material, like we have done many times before:
 
   ```javascript
+  // Create a material with our land texture.
   var groundMaterial = new BABYLON.StandardMaterial("ground", scene);
   groundMaterial.diffuseTexture = new BABYLON.Texture("Earth__land.jpg", scene);
 
+  // This shows how we would apply this material to a plane. In our later
+  // example we'll replace this with CreateGroundFromHeightMap.
   var groundPlane = BABYLON.Mesh.CreatePlane("groundPlane", 200.0, scene);
+
+  // When our new mesh is read, apply our material.
   groundPlane.material = groundMaterial;
   ```
 
@@ -29,27 +34,36 @@ _Our material, a texture, applied to the plane_
 
 * **Explanations of a height map**
 
-  Understanding height maps is the main objective of this tutorial. A height map is simply a greyscale image like the one we are going to use:
+  Understanding height maps is the main objective of this tutorial. A height map is simply a grayscale image like the one we are going to use:
 
   ![HeightMap3](/img/how_to/HeightMap/worldHeightMap.jpg)
 
   This image will now be used to generate our ground, using the different variants of gray of our picture. This image is the elevation data for your ground. Each pixel’s color is interpreted as a distance of displacement or “height” from the “floor” of your mesh. So, the whiter the pixel is, the taller your mountain will be.
 
-  To help you generate those gray-scale height maps, you can use software such as “Terragen”, or ”Picogen”. 
+  To help you generate those grayscale height maps, you can use software such as “Terragen”, or ”Picogen”.
 
 * **Javascript code**
   Now let’s see this powerful function named “CreateGroundFromHeightMap”:
   ```javascript
+  // Create a material with our land texture.
+  var groundMaterial = new BABYLON.StandardMaterial("ground", scene);
+  groundMaterial.diffuseTexture = new BABYLON.Texture("Earth__land.jpg", scene);
+
+  // Use CreateGroundFromHeightMap to create a height map of 200 units by 200
+  // units, with 250 subdivisions in each of the `x` and `z` directions, for a
+  // total of 62,500 divisions.
   var ground = BABYLON.Mesh.CreateGroundFromHeightMap("ground", "worldHeightMap.jpg", 200, 200, 250, 0, 10, scene, false, successCallback);
+
+  // When our new mesh is read, apply our material.
+  ground.material = groundMaterial;
   ```
   
-  Many parameters here:
+  There are many parameters here:
   * _Name_
   * _Height map picture url_
-  * Size of this mesh: 
-  * _Width_
-  * _Height_
-  * _Number of subdivisions_: increase the complexity of this mesh in order to improve the visual quality of it
+  * _Width of mesh_
+  * _Height of mesh_
+  * _Number of subdivisions_: increase the complexity of this mesh in order to improve the visual quality of the result
 
   ![HeightMap4](/img/how_to/HeightMap/14-2.png)
 
@@ -59,12 +73,7 @@ _Our material, a texture, applied to the plane_
   * _Updatable_: indicates if this mesh can be updated dynamically in the future (Boolean)
   * _successCallback_ : will be called after the height map was created and the vertex data is created. It is a function with the mesh as its first variable.
 
-  Finally, when our new mesh is ready, we simply apply our material:
-  ```javascript
-  ground.material = groundMaterial;
-  ```
-
-  And now we have a beautiful 3D view of the earth!
+  Now we have a beautiful 3D view of the earth!
 
   ![HeightMap4](/img/how_to/HeightMap/14-3.png)
 
@@ -75,7 +84,7 @@ _Our material, a texture, applied to the plane_
   ![HeightMap5](/img/how_to/HeightMap/14-4.png)
 
 * **Tips**
-  When the user is manipulating the camera, it can be awkward if he can see under the ground, or if he zooms-out outside the skybox. So, to avoid that kind of situation, we can constrain the camera movement:
+  When the user is manipulating the camera, it can be awkward if they can see under the ground, or if they zoom-out outside the skybox. So, to avoid that kind of situation, we can constrain the camera movement:
 
   ```javascript
   var camerasBorderFunction = function () {


### PR DESCRIPTION
These changes were based on my own usage of the docs.

 * Include more verbose JS in examples for clarity
 * Clarify subdivisions, which are in each of the "x" and "z" axis rather than the total subdivisions
 * Use "grayscale" vs. "greyscale" or "gray-scale" for greater consistency across all docs
 * Remove gendering from tips