### PR TITLE
Fix texture loading issues with Hardware Instancing Example when using Playground locally.

### DIFF
--- a/content/How_To/mesh/How_to_use_Instances.md
+++ b/content/How_To/mesh/How_to_use_Instances.md
@@ -44,4 +44,4 @@ https://www.babylonjs-playground.com/#0720FC#10
 If you want to create an instance from a cloned mesh, you have to first make sure that you call clonedMesh.makeGeometryUnique().
 
 # Demo
-https://www.babylonjs-playground.com/#YB006J#0
+https://www.babylonjs-playground.com/#YB006J#75

--- a/examples/list.json
+++ b/examples/list.json
@@ -468,7 +468,7 @@
                     "doc": "https://doc.babylonjs.com/how_to/how_to_use_instances",
                     "icon": "icons/instances.jpg",
                     "description": "Use hardware instancing to duplicate meshes at no cost",
-                    "PGID": "#YB006J#0"
+                    "PGID": "#YB006J#75"
                 },
                 {
                     "title": "Octrees",


### PR DESCRIPTION
When playing around with instances I noticed errors when trying to load the example locally.
Following the other examples I turned "/textures/*" -> "textures/*" in order to avoid loading problems when using Playground locally.

Error while trying to load image: /textures/skybox_nx.jpg
Error while trying to load image: /textures/ground.jpg
Error while trying to load image: /textures/heightMap.png

I hope this is the accepted way of fixing this. Saving -> Changing link in list and docs.
Will check the other examples for the same issues in the following days if this is ok.