### PR TITLE
Fix Special FX Example Asset Links

### DIFF
--- a/content/How_To/material/Reflect.md
+++ b/content/How_To/material/Reflect.md
@@ -61,7 +61,7 @@ material.reflectionTexture.boundingBoxSize = new BABYLON.Vector3(100, 100, 100);
 
 You can also specify a property named `boundingBoxPosition` if you want to define the center of the bounding box used for the cubemap (The place where the camera was set when generating the cubemap).
 
-You can find an demo of local cubemaps here: https://www.babylonjs-playground.com/#RNASML#4
+You can find an demo of local cubemaps here: https://www.babylonjs-playground.com/#RNASML#37
 
 ### HDRCubeTexture
 High Dynamic Range (HDR) images are panoramic images that cover an entire field of vision.

--- a/content/extensions/PostProcessLibrary/OceanPostProcess.md
+++ b/content/extensions/PostProcessLibrary/OceanPostProcess.md
@@ -50,7 +50,7 @@ postProcess.reflectionEnabled = true;
 postProcess.refractionEnabled = true;
 ```
 
-Finally, once reflection or refraction is/are enabled, just populate the render list of each render target. For more information about render targets and render list, you can refer to this playground: https://playground.babylonjs.com/#CJWDJR#0
+Finally, once reflection or refraction is/are enabled, just populate the render list of each render target. For more information about render targets and render list, you can refer to this playground: https://playground.babylonjs.com/#CJWDJR#1
 
 Example:
 ```

--- a/examples/list.json
+++ b/examples/list.json
@@ -834,7 +834,7 @@
                     "doc": "https://doc.babylonjs.com/how_to/how_to_use_reflection_probes",
                     "icon": "icons/refraction.jpg",
                     "description": "use reflection probes to simulate realtime refraction",
-                    "PGID": "#RRYXWN#0"
+                    "PGID": "#RRYXWN#1"
                 },
                 {
                     "title": "Realtime reflection",

--- a/examples/list.json
+++ b/examples/list.json
@@ -951,7 +951,7 @@
                     "doc": "https://doc.babylonjs.com/api/classes/babylon.rendertargettexture",
                     "icon": "icons/custom_rendertarget.jpg",
                     "description": "Use render target textures to generate procedural data",
-                    "PGID": "#CJWDJR#0"
+                    "PGID": "#CJWDJR#1"
                 },
                 {
                     "title": "Bump texture",

--- a/examples/list.json
+++ b/examples/list.json
@@ -855,7 +855,7 @@
                     "doc": "https://doc.babylonjs.com/how_to/highlight_layer",
                     "icon": "icons/highlights.jpg",
                     "description": "Highlight a mesh",
-                    "PGID": "#7EESGZ#0"
+                    "PGID": "#7EESGZ#8"
                 },
                 {
                     "title": "Lens effects",

--- a/examples/list.json
+++ b/examples/list.json
@@ -848,7 +848,7 @@
                     "doc": "https://doc.babylonjs.com/how_to/using_standard_rendering_pipeline#setting-up-the-motion-blur",
                     "icon": "icons/motion_blur.jpg",
                     "description": "Use the standard rendering pipeline to simulate motion blur",
-                    "PGID": "#ZMAJZB#0"
+                    "PGID": "#ZMAJZB#7"
                 },
                 {
                     "title": "Highlight layer",

--- a/examples/list.json
+++ b/examples/list.json
@@ -923,7 +923,7 @@
                     "doc": "https://doc.babylonjs.com/how_to/reflect#cubetexture",
                     "icon": "icons/local_cubemap.jpg",
                     "description": "Improve cubemaps with local mode",
-                    "PGID": "#RNASML#4"
+                    "PGID": "#RNASML#37"
                 },
                 {
                     "title": "Starfield procedural texture",

--- a/examples/list.json
+++ b/examples/list.json
@@ -722,7 +722,7 @@
                     "doc": "https://doc.babylonjs.com/how_to/how_to_use_lens_flares",
                     "icon": "icons/lens_flares.jpg",
                     "description": "Simulate lens flares on the camera",
-                    "PGID": "#ZEB7H6#0"
+                    "PGID": "#ZEB7H6#6"
                 },
                 {
                     "title": "Glass wubble ball",

--- a/examples/list.json
+++ b/examples/list.json
@@ -715,7 +715,7 @@
                     "doc": "https://doc.babylonjs.com/api/classes/babylon.convolutionpostprocess",
                     "icon": "icons/convolution.jpg",
                     "description": "Apply emboss filter to the scene using the ConvolutionPostProcess",
-                    "PGID": "#B0RH9H#0"
+                    "PGID": "#B0RH9H#1"
                 },
                 {
                     "title": "Lens flares",

--- a/examples/list.json
+++ b/examples/list.json
@@ -958,7 +958,7 @@
                     "doc": "https://doc.babylonjs.com/how_to/more_materials#bump-map",
                     "icon": "icons/bump.jpg",
                     "description": "Use normal map to simulate bump",
-                    "PGID": "#RK0W5S#0"
+                    "PGID": "#RK0W5S#30"
                 },
                 {
                     "title": "Image texture",


### PR DESCRIPTION
Fixed texture paths in the Special FX category that were starting with a / giving problems when running the Playground locally.

Changes:

Local cubemaps
Old: https://www.babylonjs-playground.com/#RNASML#4
New: https://www.babylonjs-playground.com/#RNASML#37

Custom render targets
Old: https://www.babylonjs-playground.com/#CJWDJR#0
New: https://www.babylonjs-playground.com/#CJWDJR#1

Bump texture
Old: https://www.babylonjs-playground.com/#RK0W5S#0
New: https://www.babylonjs-playground.com/#RK0W5S#30

Realtime refraction
Old: https://www.babylonjs-playground.com/#RRYXWN#0
New: https://www.babylonjs-playground.com/#RRYXWN#1

Motion blur
Old: https://www.babylonjs-playground.com/#ZMAJZB#0
New: https://www.babylonjs-playground.com/#ZMAJZB#7

Lens flares
Old: https://www.babylonjs-playground.com/#ZEB7H6#0
New: https://www.babylonjs-playground.com/#ZEB7H6#6

Highlight layer
Old: https://www.babylonjs-playground.com/#7EESGZ#0
New: https://www.babylonjs-playground.com/#7EESGZ#8

Convolution post-process
Old: https://www.babylonjs-playground.com/#B0RH9H#0
New: https://www.babylonjs-playground.com/#B0RH9H#1