### PR TITLE
Fixed table that was missing a cell

### DIFF
--- a/content/babylon101/babylon101/Parametric_Shapes.md
+++ b/content/babylon101/babylon101/Parametric_Shapes.md
@@ -53,7 +53,7 @@ For _CreateLines_ the options are
 
 option|value|default value
 --------|-----|-------------
-points|_(Vector3[])_  array of Vector3, the path of the line **REQUIRED**
+points|_(Vector3[])_  array of Vector3, the path of the line **REQUIRED** |
 updatable|_(boolean)_ true if the mesh is updatable|false
 instance|_(LineMesh)_ an instance of a line mesh to be updated|null
 colors|_(Color4[])_ array of Color4, each point color|null


### PR DESCRIPTION
This table was missing the last cell in the first row. Adding the last pipe character lets the table have an empty cell. Each row should have the same number of pipe characters. You can see how line 56 now matches the other similar row on line 66 of the same file.