### PR TITLE
remove BJS logo v3 from cornell box example

### DIFF
--- a/content/resources/Exporter/Blender.md
+++ b/content/resources/Exporter/Blender.md
@@ -4,7 +4,9 @@ PG_TITLE: Blender
 ---
 # Blender to Babylon.js exporter
 
-The Blender export plugin can be found on [github repository](https://github.com/BabylonJS/Exporters/tree/master/Blender). We assume your using the last version.
+The Blender export plugin can be found on [github repository](https://github.com/BabylonJS/BlenderExporter). We assume your using the last version.
+
+Note that v6 is for Blender 2.8 (currently in beta), v5 for Blender 2.79b or below can be found in the `deprecated` folder.
 
 An extension named [Tower of Babel](http://github.com/BabylonJS/Extensions/tree/master/QueuedInterpolation/Blender) can also be used as exporter. It exports JavaScript modules with in-line geometry and simplifies the loading process. See its readme or that of the [QueuedInterpolation](https://github.com/BabylonJS/Extensions/tree/master/QueuedInterpolation) extension, which it is part of, to know more about its functionalities, and access its proper documentation.
 
@@ -12,7 +14,7 @@ An extension named [Tower of Babel](http://github.com/BabylonJS/Extensions/tree/
 
 This add-on use the standard Blender installation procedure:
 
-- Download the [last version from github](https://github.com/BabylonJS/Exporters/tree/master/Blender) (_Blender2Babylon-X.X.zip_, you don't need to unzip).
+- Download the [last version from github](https://github.com/BabylonJS/BlenderExporter) (_Blender2Babylon-X.X.zip_, you don't need to unzip).
 - In Blender, go to `File` menu > `User Preferences`.
 - Switch to the `Add-ons` tab.
 - (optionnal) If you already have an old version installed, search for *Babylon.js* into the filter, expand infos of BabylonJS add-on and click `Remove` button.

--- a/examples/list.json
+++ b/examples/list.json
@@ -228,7 +228,7 @@
                     "doc": "https://doc.babylonjs.com/how_to/load_from_any_file_type",
                     "icon": "icons/cornell.jpg",
                     "description": "Load a glTF file and setup the environment",
-                    "PGID": "#J5E230#266"
+                    "PGID": "#G3GZA1#7"
                 },
                 {
                     "title": "Import meshes",


### PR DESCRIPTION
as seen in PM with Patrick Ryan, old BJS v3 logo is removed from official examples

https://www.babylonjs-playground.com/#G3GZA1#7
