### PR TITLE
Add how to disappear default controller mesh

### DIFF
--- a/content/How_To/camera/WebVR_Camera.md
+++ b/content/How_To/camera/WebVR_Camera.md
@@ -261,7 +261,7 @@ controller.attachToMesh(mesh);
 
 Note that this will create a new quaternion to the mesh .
 
-The default controller mesh can be disappeared by the following code.
+The default controller mesh can be hidden with the following code.
 
 ```javascript
  scene.createDefaultVRExperience({controllerMeshes:true});

--- a/content/How_To/camera/WebVR_Camera.md
+++ b/content/How_To/camera/WebVR_Camera.md
@@ -261,6 +261,12 @@ controller.attachToMesh(mesh);
 
 Note that this will create a new quaternion to the mesh .
 
+The default controller mesh can be disappeared by the following code.
+
+```javascript
+ scene.createDefaultVRExperience({controllerMeshes:true});
+```
+
 
 ### Low level fun
 


### PR DESCRIPTION
Only using attachToMesh() function remains native controller meshes. The option of "controllerMeshes:false" can be disappeared the native meshes.

See controllerMeshes option of the link.   
https://doc.babylonjs.com/api/interfaces/babylon.vrexperiencehelperoptions