### PR TITLE
Target camera constructor

### DIFF
--- a/typedoc/babylon.d.ts
+++ b/typedoc/babylon.d.ts
@@ -8300,7 +8300,7 @@ declare module BABYLON {
         _reset: () => void;
         private _defaultUp;
         /**
-         * Instantiates a target camera that takes a meshor position as a target and continues to look at it while it moves.
+         * Instantiates a target camera that takes a mesh or position as a target and continues to look at it while it moves.
          * This is the base of the follow, arc rotate cameras and Free camera
          * @see http://doc.babylonjs.com/features/cameras
          * @param name Defines the name of the camera in the scene


### PR DESCRIPTION
In the `TargetCamera` constructor, I believe "meshor" is errata.

Update to state: “mesh or position as target”