### PR TITLE
Correct url to easings.net

### DIFF
--- a/content/babylon101/babylon101/Animations.md
+++ b/content/babylon101/babylon101/Animations.md
@@ -323,7 +323,7 @@ Please note that the scene.animationPropertiesOverride will be used if animation
 You can add some behaviors to your animations, using easing functions. 
 If you want more information about easing functions, here are some useful links : 
 - [MSDN Easing functions documentation](http://msdn.microsoft.com/en-us/library/ee308751.aspx)
-- [Easing functions cheat sheet](http://easings.net/fr)
+- [Easing functions cheat sheet](https://easings.net)
 
 All those easing functions are implemented in BABYLON, allowing you to apply custom mathematical formulas to your animations.
 


### PR DESCRIPTION
Unsure what they changed, but a direct link to the language of choice appears to not work.  Corrected url to base site, which will detect language.