### PR TITLE
Fix device orientation camera sample

### DIFF
--- a/content/babylon101/babylon101/Cameras.md
+++ b/content/babylon101/babylon101/Cameras.md
@@ -52,7 +52,7 @@ The default actions are:
 // Attach the camera to the canvas
     camera.attachControl(canvas, true);
 ```
-[A Playground Example of a Universal Camera](http://www.babylonjs-playground.com/#12WBC#68)
+[A Playground Example of a Universal Camera](http://www.babylonjs-playground.com/#12WBC#702)
 
 
 ## Arc Rotate Camera
@@ -87,7 +87,7 @@ Whether using the keyboard, mouse or touch swipes left right directions change _
 // This attaches the camera to the canvas
     camera.attachControl(canvas, true);
 ```
-[A Playground Example of an Arc Rotate Camera](http://www.babylonjs-playground.com/#12WBC#69)
+[A Playground Example of an Arc Rotate Camera](http://www.babylonjs-playground.com/#12WBC#702)
 
 Panning with an ArcRotateCamera is also possible by using CTRL + MouseLeftClick, the default action. You can specify to use MouseRightClick instead, by setting _useCtrlForPanning_ to false in the _attachControl_ call :
 
@@ -146,7 +146,7 @@ camera.attachControl(canvas, true);
 camera.target = targetMesh;   // version 2.4 and earlier
 camera.lockedTarget = targetMesh; //version 2.5 onwards
 ```
-[A Playground Example of a Follow Camera following a moving target](http://www.babylonjs-playground.com/#12WBC#84)
+[A Playground Example of a Follow Camera following a moving target](http://www.babylonjs-playground.com/#12WBC#702)
 
 
 ## AnaglyphCameras
@@ -195,7 +195,7 @@ This is a camera specifically designed to react to device orientation events suc
     camera.attachControl(canvas, true);
 
 ```
-[A Playground Example of a Device Orientation Camera](http://www.babylonjs-playground.com/#12WBC#81) for those with a correct device.
+[A Playground Example of a Device Orientation Camera](http://www.babylonjs-playground.com/#12WBC#702) for those with a correct device.
 
 ## Virtual Joysticks Camera
 
@@ -257,7 +257,7 @@ If you switch back to another camera, don’t forget to call the dispose() funct
 ## VR Device Orientation Cameras
 
 A new range of cameras.
-[A Playground Example of a VR Device Orientation Camera](http://www.babylonjs-playground.com/#12WBC#80) for those with a correct device.
+[A Playground Example of a VR Device Orientation Camera](http://www.babylonjs-playground.com/#12WBC#702) for those with a correct device.
 
 ### Constructing the VR Device Orientation Free Camera
 

--- a/examples/list.json
+++ b/examples/list.json
@@ -69,7 +69,7 @@
                     "doc": "https://doc.babylonjs.com/babylon101/cameras#device-orientation-camera",
                     "icon": "icons/deviceOrientationCamera.jpg",
                     "description": "Camera that reacts to events such as a mobile device being tilted forward or back",
-                    "PGID": "#12WBC#185"
+                    "PGID": "#12WBC#702"
                 }
             ]
         },


### PR DESCRIPTION
Wrong BABYLON.Color3 usage. (rgb 0..255 style)

Scene diff:

```diff
 	//Materials
 	var redMat = new BABYLON.StandardMaterial("red", scene);
-	redMat.diffuseColor = new BABYLON.Color3(255, 0, 0);
-	redMat.emissiveColor = new BABYLON.Color3(255, 0, 0);
-	redMat.specularColor = new BABYLON.Color3(255, 0, 0);
+	redMat.diffuseColor = new BABYLON.Color3(1, 0, 0);
+	redMat.emissiveColor = new BABYLON.Color3(1, 0, 0);
+	redMat.specularColor = new BABYLON.Color3(1, 0, 0);
 	
 	var greenMat = new BABYLON.StandardMaterial("green", scene);
-	greenMat.diffuseColor = new BABYLON.Color3(0, 255, 0);
-	greenMat.emissiveColor = new BABYLON.Color3(0, 255, 0);
-	greenMat.specularColor = new BABYLON.Color3(0, 255, 0);
+	greenMat.diffuseColor = new BABYLON.Color3(0, 1, 0);
+	greenMat.emissiveColor = new BABYLON.Color3(0, 1, 0);
+	greenMat.specularColor = new BABYLON.Color3(0, 1, 0);
 	
 	var blueMat = new BABYLON.StandardMaterial("blue", scene);
-	blueMat.diffuseColor = new BABYLON.Color3(0, 0, 255);
-	blueMat.emissiveColor = new BABYLON.Color3(0, 0, 255);
-	blueMat.specularColor = new BABYLON.Color3(0, 0, 255);
+	blueMat.diffuseColor = new BABYLON.Color3(0, 0, 1);
+	blueMat.emissiveColor = new BABYLON.Color3(0, 0, 1);
+	blueMat.specularColor = new BABYLON.Color3(0, 0, 1);
 	
 	var yellowMat = new BABYLON.StandardMaterial("yellow", scene);
-	yellowMat.diffuseColor = new BABYLON.Color3(255, 255, 0);
-	yellowMat.emissiveColor = new BABYLON.Color3(255, 255, 0);
-	yellowMat.specularColor = new BABYLON.Color3(255, 255, 0);
+	yellowMat.diffuseColor = new BABYLON.Color3(1, 1, 0);
+	yellowMat.emissiveColor = new BABYLON.Color3(1, 1, 0);
+	yellowMat.specularColor = new BABYLON.Color3(1, 1, 0);
 	
 	var orangeMat = new BABYLON.StandardMaterial("orange", scene);
-	orangeMat.diffuseColor = new BABYLON.Color3(253, 188, 3);
-	orangeMat.emissiveColor = new BABYLON.Color3(253, 188, 3);
-	orangeMat.specularColor = new BABYLON.Color3(253, 188, 3);
+	orangeMat.diffuseColor = new BABYLON.Color3(0.98, 0.7, 0);
+	orangeMat.emissiveColor = new BABYLON.Color3(0.98, 0.7, 0);
+	orangeMat.specularColor = new BABYLON.Color3(0.98, 0.7, 0);
 	
 	var purpleMat = new BABYLON.StandardMaterial("purple", scene);
-	purpleMat.diffuseColor = new BABYLON.Color3(255, 0, 255);
-	purpleMat.emissiveColor = new BABYLON.Color3(255, 0, 255);
-	purpleMat.specularColor = new BABYLON.Color3(255, 0, 255);
+	purpleMat.diffuseColor = new BABYLON.Color3(1, 0, 1);
+	purpleMat.emissiveColor = new BABYLON.Color3(1, 0, 1);
+	purpleMat.specularColor = new BABYLON.Color3(1, 0, 1);
 	
 	// Shapes
 	var box1 = BABYLON.MeshBuilder.CreateBox("box1", {size: 5}, scene);
```