### PR TITLE
Correct Fix Samples

### DIFF
--- a/content/babylon101/babylon101/Cameras.md
+++ b/content/babylon101/babylon101/Cameras.md
@@ -52,7 +52,7 @@ The default actions are:
 // Attach the camera to the canvas
     camera.attachControl(canvas, true);
 ```
-[A Playground Example of a Universal Camera](http://www.babylonjs-playground.com/#12WBC#702)
+[A Playground Example of a Universal Camera](https://www.babylonjs-playground.com/#SRZRWV)
 
 
 ## Arc Rotate Camera
@@ -87,7 +87,7 @@ Whether using the keyboard, mouse or touch swipes left right directions change _
 // This attaches the camera to the canvas
     camera.attachControl(canvas, true);
 ```
-[A Playground Example of an Arc Rotate Camera](http://www.babylonjs-playground.com/#12WBC#702)
+[A Playground Example of an Arc Rotate Camera](https://www.babylonjs-playground.com/#SRZRWV#1)
 
 Panning with an ArcRotateCamera is also possible by using CTRL + MouseLeftClick, the default action. You can specify to use MouseRightClick instead, by setting _useCtrlForPanning_ to false in the _attachControl_ call :
 
@@ -146,7 +146,7 @@ camera.attachControl(canvas, true);
 camera.target = targetMesh;   // version 2.4 and earlier
 camera.lockedTarget = targetMesh; //version 2.5 onwards
 ```
-[A Playground Example of a Follow Camera following a moving target](http://www.babylonjs-playground.com/#12WBC#702)
+[A Playground Example of a Follow Camera following a moving target](https://www.babylonjs-playground.com/#SRZRWV#6)
 
 
 ## AnaglyphCameras
@@ -195,7 +195,7 @@ This is a camera specifically designed to react to device orientation events suc
     camera.attachControl(canvas, true);
 
 ```
-[A Playground Example of a Device Orientation Camera](http://www.babylonjs-playground.com/#12WBC#702) for those with a correct device.
+[A Playground Example of a Device Orientation Camera](https://www.babylonjs-playground.com/#SRZRWV#3) for those with a correct device.
 
 ## Virtual Joysticks Camera
 
@@ -257,7 +257,7 @@ If you switch back to another camera, don’t forget to call the dispose() funct
 ## VR Device Orientation Cameras
 
 A new range of cameras.
-[A Playground Example of a VR Device Orientation Camera](http://www.babylonjs-playground.com/#12WBC#702) for those with a correct device.
+[A Playground Example of a VR Device Orientation Camera](https://www.babylonjs-playground.com/#SRZRWV#4) for those with a correct device.
 
 ### Constructing the VR Device Orientation Free Camera
 

--- a/examples/list.json
+++ b/examples/list.json
@@ -69,7 +69,7 @@
                     "doc": "https://doc.babylonjs.com/babylon101/cameras#device-orientation-camera",
                     "icon": "icons/deviceOrientationCamera.jpg",
                     "description": "Camera that reacts to events such as a mobile device being tilted forward or back",
-                    "PGID": "#12WBC#702"
+                    "PGID": "#SRZRWV#5"
                 }
             ]
         },


### PR DESCRIPTION
Re https://forum.babylonjs.com/t/tutorial-101-bugs/6633

Unfortunately when @sailro correctly made corrections to the Color3s in the playgrounds for PR #1749 he corrected one playground and then used that one for all the examples even though there were differences in camera. Have now done the individual examples for the different cameras. 