### PR TITLE
Fix link to custom joystick playground

### DIFF
--- a/content/How_To/events/How_to_use_Virtual_Joysticks.md
+++ b/content/How_To/events/How_to_use_Virtual_Joysticks.md
@@ -23,6 +23,6 @@ Note: This will create an overlay canvas on top of the canvas for the scene. Thi
 
 To create a custom virtual joystick and modify it to suit specific use cases, the Babylon GUI can be used.
 
-* [Playground Example](https://playground.babylonjs.com/#PRQU53)
+* [Playground Example](https://www.babylonjs-playground.com/#C6V6UY#5)
 
 As seen in this example, no overlay canvas is used so other GUI elements will continue to function and the visuals can be modified/positioned if needed.


### PR DESCRIPTION
Currently, both examples are leading to the same playground. A proper link to custom joystick playground was taken from this forum topic - https://forum.babylonjs.com/t/gui-does-not-work-with-joystick-and-alternative-to-joystick/2032/13.