### PR TITLE
Added a note about adaptToDeviceRatio

### DIFF
--- a/content/How_To/GUI/Gui.md
+++ b/content/How_To/GUI/Gui.md
@@ -917,6 +917,11 @@ engine.runRenderLoop(function() {
 
 In this case the `guiScene` will host your GUI and the `mainScene` will host your scene with your postprocesses.
 
+## GUI and HighDPI Displays
+
+If you are viewing the scene on a high dpi (or "retina") device (such as many mobile devices, or some laptops), you may notice that text on the UI appears "blurry" or "pixelated". This is because, starting in Babylon.js v2.6, the engine no longer defaults to adapting to the device pixel ratio. This was done for performance reasons on mobile devices; turning it on can have a large impact on performance. To improve the rendering of text (at the cost of performance), you will need to enable the `adaptToDeviceRatio` option when constructing your engine.
+
+Please see [Turning AdaptToDeviceRatio Off/On](how_to/scene/Optimizing_your_scene.md#turning-adapttodeviceratio-offon) for more information on the trade offs.
 
 ## Further reading
 


### PR DESCRIPTION
This is an attempt to make clear that issues with "blurry text" are most likely related to the device pixel ratio. This has caught several uses off guard, myself included.

Please see [this Discord thread](https://forum.babylonjs.com/t/improve-highdpi-support-especially-for-babylon-gui/7796) for the discussion.