### PR TITLE
Replace http with https

### DIFF
--- a/content/resources/Playground_aspects/Playground_Textures.md
+++ b/content/resources/Playground_aspects/Playground_Textures.md
@@ -17,75 +17,75 @@ new BABYLON.Texture("textures/filename", scene);
 | Overview | Filename | Size |
 | :---: | --- | --- |
 | ![](/img/resources/textures_thumbs/albedo.png.jpg) | albedo.png | 590 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/amiga.jpg' width = '64' height = '64'> | amiga.jpg | 2 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/BJS-logo_v3.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | BJS-logo_v3.png <br>[(ktx available)](https://doc.babylonjs.com/resources/multi-platform_compressed_textures) | 39 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/bloc.jpg' width = '64' height = '64'> | bloc.jpg | 3 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/checkerBJS.png' width = '64' height = '64'> | checkerBJS.png <br>[(ktx available)](https://doc.babylonjs.com/resources/multi-platform_compressed_textures) | 38 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/cloud.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | cloud.png | 58 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/lava/cloud.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | lava/cloud.png | 81 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/co.png' width = '64' height = '64'> | co.png | 2 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/crate.png' width = '64' height = '64'> | crate.png | 80 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/amiga.jpg' width = '64' height = '64'> | amiga.jpg | 2 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/BJS-logo_v3.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | BJS-logo_v3.png <br>[(ktx available)](https://doc.babylonjs.com/resources/multi-platform_compressed_textures) | 39 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/bloc.jpg' width = '64' height = '64'> | bloc.jpg | 3 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/checkerBJS.png' width = '64' height = '64'> | checkerBJS.png <br>[(ktx available)](https://doc.babylonjs.com/resources/multi-platform_compressed_textures) | 38 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/cloud.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | cloud.png | 58 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/lava/cloud.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | lava/cloud.png | 81 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/co.png' width = '64' height = '64'> | co.png | 2 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/crate.png' width = '64' height = '64'> | crate.png | 80 KB |
 | ![](/img/resources/textures_thumbs/earth.jpg) | earth.jpg | 261KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/fire.png' width = '64' height = '64'> | fire.png | 44 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/fire.png' width = '64' height = '64'> | fire.png | 44 KB |
 | ![](/img/resources/textures_thumbs/floor.png.jpg) | floor.png | 509 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/fur.jpg' width = '64' height = '64'> | fur.jpg | 140 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/fur.jpg' width = '64' height = '64'> | fur.jpg | 140 KB |
 | ![](/img/resources/textures_thumbs/grass.jpg) | grass.jpg | 750 KB |
 | ![](/img/resources/textures_thumbs/grass.dds.jpg) | grass.dds | 43 KB |
 | ![](/img/resources/textures_thumbs/grass.png.jpg) | grass.png | 620 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/ground.jpg' width = '64' height = '64'> | ground.jpg | 506 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/lava/lavatile.jpg' width = '64' height = '64'> | `lava/lavatile.jpg` | 546 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/leopard_fur.JPG' width = '64' height = '64'> | leopard_fur.JPG | 9 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/Logo.png' width = '64' height = '32' > | Logo.png | 12 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/mercator.jpg' width = '128' height = '64'> | mercator.jpg | 977 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/mercator2.jpg' width = '128' height = '64'> | mercator2.jpg | 87 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/palm.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | palm.png | 392 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/rock.png' width = '64' height = '64'> | rock.png | 260 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/sand.jpg' width = '64' height = '64'> | sand.jpg | 496 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/speckles.jpg' width = '64' height = '64'> | speckles.jpg | 7 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/stars.png' width = '64' height = '32'> | stars.png | 188 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/sun.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | sun.png | 7 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/ground.jpg' width = '64' height = '64'> | ground.jpg | 506 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/lava/lavatile.jpg' width = '64' height = '64'> | `lava/lavatile.jpg` | 546 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/leopard_fur.JPG' width = '64' height = '64'> | leopard_fur.JPG | 9 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Logo.png' width = '64' height = '32' > | Logo.png | 12 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/mercator.jpg' width = '128' height = '64'> | mercator.jpg | 977 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/mercator2.jpg' width = '128' height = '64'> | mercator2.jpg | 87 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/palm.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | palm.png | 392 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/rock.png' width = '64' height = '64'> | rock.png | 260 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/sand.jpg' width = '64' height = '64'> | sand.jpg | 496 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/speckles.jpg' width = '64' height = '64'> | speckles.jpg | 7 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/stars.png' width = '64' height = '32'> | stars.png | 188 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/sun.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | sun.png | 7 KB |
 | <img src = '/img/resources/textures_thumbs/SunDiffuse.png' width = '128' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | SunDiffuse.png | 799 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/tree.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | tree.png | 304 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/tree.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | tree.png | 304 KB |
 
 ## Height maps
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/distortion.png' width = '64' height = '64'> | distortion.png | 42 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/heightMap.png' width = '64' height = '64'> | heightMap.png | 39 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/heightMapTriPlanar.png' width = '64' height = '64'> | heightMapTriPlanar.png | 44 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/worldHeightMap.jpg' width = '64' height = '32'> | worldHeightMap.jpg | 92 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/distortion.png' width = '64' height = '64'> | distortion.png | 42 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/heightMap.png' width = '64' height = '64'> | heightMap.png | 39 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/heightMapTriPlanar.png' width = '64' height = '64'> | heightMapTriPlanar.png | 44 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/worldHeightMap.jpg' width = '64' height = '32'> | worldHeightMap.jpg | 92 KB |
 
 ## Metallic maps
 
 | Overview | Filename | Size |
 | :---: | --- |  --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/reflectivity.png' width = '64' height = '64'> | reflectivity.png | 92 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/reflectivity.png' width = '64' height = '64'> | reflectivity.png | 92 KB |
 
 ## Normal maps
 
 | Overview | Filename | Size |
 | :---: | --- |  --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/floor_bump.PNG' width = '64' height = '64'> | floor_bump.PNG | 329 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/grassn.png' width = '64' height = '64'> | grassn.png | 156 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/normal.png' width = '64' height = '64'> | normal.png | 695 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/normalMap.jpg' width = '64' height = '64'> | normalMap.jpg | 68 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/rockn.png' width = '64' height = '64'> | rockn.png | 700 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/waterbump.png' width = '64' height = '64'> | waterbump.png | 68 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/floor_bump.PNG' width = '64' height = '64'> | floor_bump.PNG | 329 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/grassn.png' width = '64' height = '64'> | grassn.png | 156 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/normal.png' width = '64' height = '64'> | normal.png | 695 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/normalMap.jpg' width = '64' height = '64'> | normalMap.jpg | 68 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/rockn.png' width = '64' height = '64'> | rockn.png | 700 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/waterbump.png' width = '64' height = '64'> | waterbump.png | 68 KB |
 
 ## Opacity / Alpha maps
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/candleopacity.png' width = '64' height = '64'> | candleopacity.png | 18 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/opacity.png' width = '64' height = '64'> | opacity.png | 26 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/WhiteTransarentRamp.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | WhiteTransarentRamp.png | 223 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/candleopacity.png' width = '64' height = '64'> | candleopacity.png | 18 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/opacity.png' width = '64' height = '64'> | opacity.png | 26 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/WhiteTransarentRamp.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | WhiteTransarentRamp.png | 223 KB |
 
 ## Sphere maps
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/sphereMap.png' width = '64' height = '64'> | sphereMap.png | 340 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/sphereMap.png' width = '64' height = '64'> | sphereMap.png | 340 KB |
 | ![](/img/resources/textures_thumbs/test2D.dds.jpg) | test2D.dds | 2 MB |
 
 ## 360° Equirectangular maps (for PhotoDome)
@@ -117,14 +117,14 @@ new BABYLON.CubeTexture("textures/common part of filenames", scene);
 
 | Overview | Filename | Viewer | Size |
 | :---: | --- | --- | --- |
-| ![](/img/resources/textures_thumbs/cubemapDebug.jpg) | cubemapDebug/ <br>[(ktx available)](https://doc.babylonjs.com/resources/multi-platform_compressed_textures) | [take a look](http://www.babylonjs-playground.com/#UU7RQ#322) | 6 x 80 KB |
-| ![](/img/resources/textures_thumbs/skybox.jpg) | skybox | [take a look](http://www.babylonjs-playground.com/#UU7RQ#91) | 6 x 20 KB |
-| ![](/img/resources/textures_thumbs/skybox2.jpg) | skybox2 | [take a look](http://www.babylonjs-playground.com/#UU7RQ#92) | 6 x 400 KB |
-| ![](/img/resources/textures_thumbs/skybox3.jpg) | skybox3 | [take a look](http://www.babylonjs-playground.com/#UU7RQ#93) | 6 x 150 KB |
-| ![](/img/resources/textures_thumbs/skybox4.jpg) | skybox4 | [take a look](http://www.babylonjs-playground.com/#UU7RQ#94) | 6 x 150 KB |
+| ![](/img/resources/textures_thumbs/cubemapDebug.jpg) | cubemapDebug/ <br>[(ktx available)](https://doc.babylonjs.com/resources/multi-platform_compressed_textures) | [take a look](https://www.babylonjs-playground.com/#UU7RQ#322) | 6 x 80 KB |
+| ![](/img/resources/textures_thumbs/skybox.jpg) | skybox | [take a look](https://www.babylonjs-playground.com/#UU7RQ#91) | 6 x 20 KB |
+| ![](/img/resources/textures_thumbs/skybox2.jpg) | skybox2 | [take a look](https://www.babylonjs-playground.com/#UU7RQ#92) | 6 x 400 KB |
+| ![](/img/resources/textures_thumbs/skybox3.jpg) | skybox3 | [take a look](https://www.babylonjs-playground.com/#UU7RQ#93) | 6 x 150 KB |
+| ![](/img/resources/textures_thumbs/skybox4.jpg) | skybox4 | [take a look](https://www.babylonjs-playground.com/#UU7RQ#94) | 6 x 150 KB |
 | ![](/img/resources/textures_thumbs/skyboxBlack.jpg) | skyboxBlack | [take a look](https://www.babylonjs-playground.com/#UU7RQ#344) | 6 x 7 KB |
-| ![](/img/resources/textures_thumbs/space.jpg) | space | [take a look](http://www.babylonjs-playground.com/#UU7RQ#245) | 6 x 200 KB |
-| ![](/img/resources/textures_thumbs/TropicalSunnyDay.jpg) | TropicalSunnyDay | [take a look](http://www.babylonjs-playground.com/#UU7RQ#95) | 6 x 600 KB |
+| ![](/img/resources/textures_thumbs/space.jpg) | space | [take a look](https://www.babylonjs-playground.com/#UU7RQ#245) | 6 x 200 KB |
+| ![](/img/resources/textures_thumbs/TropicalSunnyDay.jpg) | TropicalSunnyDay | [take a look](https://www.babylonjs-playground.com/#UU7RQ#95) | 6 x 600 KB |
 
 
 ### HDR
@@ -137,12 +137,12 @@ new BABYLON.HDRCubeTexture("textures/filename", scene);
 
 | Overview | Filename | Viewer | Size |
 | :---: | --- | --- | --- |
-| ![](/img/resources/textures_thumbs/country.hdr.jpg) | country.hdr | [take a look](http://playground.babylonjs.com/#CGA05F) | 5.8 MB |
-| ![](/img/resources/textures_thumbs/environment.hdr.jpg) | environment.hdr | [take a look](http://playground.babylonjs.com/#CGA05F#9) | 5.8 MB |
-| ![](/img/resources/textures_thumbs/forest.hdr.jpg) | forest.hdr | [take a look](http://playground.babylonjs.com/#CGA05F#3) | 7.2 MB |
-| ![](/img/resources/textures_thumbs/night.hdr.jpg) | night.hdr | [take a look](http://playground.babylonjs.com/#CGA05F#4) | 5.6 MB |
-| ![](/img/resources/textures_thumbs/parking.hdr.jpg) | parking.hdr | [take a look](http://playground.babylonjs.com/#CGA05F#5) | 6.1 MB |
-| ![](/img/resources/textures_thumbs/room.hdr.jpg) | room.hdr | [take a look](http://playground.babylonjs.com/#CGA05F#6) | 5.7 MB |
+| ![](/img/resources/textures_thumbs/country.hdr.jpg) | country.hdr | [take a look](https://www.babylonjs-playground.com/#CGA05F) | 5.8 MB |
+| ![](/img/resources/textures_thumbs/environment.hdr.jpg) | environment.hdr | [take a look](https://playground.babylonjs.com/#CGA05F#9) | 5.8 MB |
+| ![](/img/resources/textures_thumbs/forest.hdr.jpg) | forest.hdr | [take a look](https://playground.babylonjs.com/#CGA05F#3) | 7.2 MB |
+| ![](/img/resources/textures_thumbs/night.hdr.jpg) | night.hdr | [take a look](https://playground.babylonjs.com/#CGA05F#4) | 5.6 MB |
+| ![](/img/resources/textures_thumbs/parking.hdr.jpg) | parking.hdr | [take a look](https://playground.babylonjs.com/#CGA05F#5) | 6.1 MB |
+| ![](/img/resources/textures_thumbs/room.hdr.jpg) | room.hdr | [take a look](https://playground.babylonjs.com/#CGA05F#6) | 5.7 MB |
 
 ### HDR as .dds
 
@@ -154,15 +154,15 @@ new BABYLON.CubeTexture.CreateFromPrefilteredData("textures/filename", scene);
 
 | Overview | Filename | Viewer | Size |
 | :---: | --- | --- | --- |
-| ![](/img/resources/textures_thumbs/country.hdr.jpg) | country.dds | [take a look](http://playground.babylonjs.com/#CGA05F#34) | 32.77 MB |
-| ![](/img/resources/textures_thumbs/environment.dds.jpg) | environment.dds | [take a look](http://playground.babylonjs.com/#CGA05F#7) | 1 MB |
-| ![](/img/resources/textures_thumbs/forest.hdr.jpg) | forest.dds | [take a look](http://playground.babylonjs.com/#CGA05F#36) | 32.77 MB |
-| ![](/img/resources/textures_thumbs/night.hdr.jpg) | night.dds | [take a look](http://playground.babylonjs.com/#CGA05F#38) | 32.77 MB |
-| ![](/img/resources/textures_thumbs/parking.hdr.jpg) | parking.dds | [take a look](http://playground.babylonjs.com/#CGA05F#40) | 32.77 MB |
-| ![](/img/resources/textures_thumbs/room.hdr.jpg) | room.dds | [take a look](http://playground.babylonjs.com/#CGA05F#41) | 32.77 MB |
+| ![](/img/resources/textures_thumbs/country.hdr.jpg) | country.dds | [take a look](https://playground.babylonjs.com/#CGA05F#34) | 32.77 MB |
+| ![](/img/resources/textures_thumbs/environment.dds.jpg) | environment.dds | [take a look](https://playground.babylonjs.com/#CGA05F#7) | 1 MB |
+| ![](/img/resources/textures_thumbs/forest.hdr.jpg) | forest.dds | [take a look](https://playground.babylonjs.com/#CGA05F#36) | 32.77 MB |
+| ![](/img/resources/textures_thumbs/night.hdr.jpg) | night.dds | [take a look](https://playground.babylonjs.com/#CGA05F#38) | 32.77 MB |
+| ![](/img/resources/textures_thumbs/parking.hdr.jpg) | parking.dds | [take a look](https://playground.babylonjs.com/#CGA05F#40) | 32.77 MB |
+| ![](/img/resources/textures_thumbs/room.hdr.jpg) | room.dds | [take a look](https://playground.babylonjs.com/#CGA05F#41) | 32.77 MB |
 | ![](/img/resources/textures_thumbs/Runyon_Canyon_A_2k_cube_specular.dds.jpg) | Runyon_Canyon_A_2k_cube_specular.dds | [take a look](https://playground.babylonjs.com/#CGA05F#26) | 8 MB |
-| ![](/img/resources/textures_thumbs/SpecularHDR.dds.jpg) | SpecularHDR.dds | [take a look](http://playground.babylonjs.com/#CGA05F#8) | 16 MB |
-| ![](/img/resources/textures_thumbs/Studio_Softbox_2Umbrellas_cube_specular.dds.jpg) | Studio_Softbox_2Umbrellas_cube_specular.dds | [take a look](http://playground.babylonjs.com/#CGA05F#24) | 8 MB |
+| ![](/img/resources/textures_thumbs/SpecularHDR.dds.jpg) | SpecularHDR.dds | [take a look](https://playground.babylonjs.com/#CGA05F#8) | 16 MB |
+| ![](/img/resources/textures_thumbs/Studio_Softbox_2Umbrellas_cube_specular.dds.jpg) | Studio_Softbox_2Umbrellas_cube_specular.dds | [take a look](https://playground.babylonjs.com/#CGA05F#24) | 8 MB |
 
 In the Playground use
 
@@ -172,7 +172,7 @@ myMaterial.environmentBRDFTexture = new BABYLON.Texture("https://assets.babylonj
 
 | Overview | Filename | Viewer | Size | Comment |
 | :---: | --- | --- | --- | --- |
-| ![](/img/resources/textures_thumbs/environment.dds.jpg) | fullFloatEnvironmentBrdf.dds | [take a look](http://playground.babylonjs.com/#CGA05F#11) | 1.25 MB | [32 bit version](https://github.com/BabylonJS/Babylon.js/issues/4156#issuecomment-382982858) of the environment.dds file |
+| ![](/img/resources/textures_thumbs/environment.dds.jpg) | fullFloatEnvironmentBrdf.dds | [take a look](https://playground.babylonjs.com/#CGA05F#11) | 1.25 MB | [32 bit version](https://github.com/BabylonJS/Babylon.js/issues/4156#issuecomment-382982858) of the environment.dds file |
 
 ### HDR as .env
 
@@ -184,15 +184,15 @@ new BABYLON.CubeTexture("textures/filename", scene);
 
 | Overview | Filename | Viewer | Size |
 | :---: | --- | --- | --- |
-| ![](/img/resources/textures_thumbs/country.hdr.jpg) | country.env | [take a look](http://playground.babylonjs.com/#CGA05F#35) | 3.72 MB |
-| ![](/img/resources/textures_thumbs/environment.dds.jpg) | environment.env | [take a look](http://playground.babylonjs.com/#CGA05F#15) | 350 KB |
-| ![](/img/resources/textures_thumbs/forest.hdr.jpg) | forest.env | [take a look](http://playground.babylonjs.com/#CGA05F#37) | 5.81 MB |
-| ![](/img/resources/textures_thumbs/night.hdr.jpg) | night.env | [take a look](http://playground.babylonjs.com/#CGA05F#39) | 2.74 MB |
-| ![](/img/resources/textures_thumbs/parking.hdr.jpg) | parking.env | [take a look](http://playground.babylonjs.com/#CGA05F#42) | 3.45 MB |
-| ![](/img/resources/textures_thumbs/room.hdr.jpg) | room.env | [take a look](http://playground.babylonjs.com/#CGA05F#43) | 4.92 MB |
+| ![](/img/resources/textures_thumbs/country.hdr.jpg) | country.env | [take a look](https://playground.babylonjs.com/#CGA05F#35) | 3.72 MB |
+| ![](/img/resources/textures_thumbs/environment.dds.jpg) | environment.env | [take a look](https://playground.babylonjs.com/#CGA05F#15) | 350 KB |
+| ![](/img/resources/textures_thumbs/forest.hdr.jpg) | forest.env | [take a look](https://playground.babylonjs.com/#CGA05F#37) | 5.81 MB |
+| ![](/img/resources/textures_thumbs/night.hdr.jpg) | night.env | [take a look](https://playground.babylonjs.com/#CGA05F#39) | 2.74 MB |
+| ![](/img/resources/textures_thumbs/parking.hdr.jpg) | parking.env | [take a look](https://playground.babylonjs.com/#CGA05F#42) | 3.45 MB |
+| ![](/img/resources/textures_thumbs/room.hdr.jpg) | room.env | [take a look](https://playground.babylonjs.com/#CGA05F#43) | 4.92 MB |
 | ![](/img/resources/textures_thumbs/Runyon_Canyon_A_2k_cube_specular.dds.jpg) | Runyon_Canyon_A_2k_cube_specular.env | [take a look](https://playground.babylonjs.com/#CGA05F#31) | 992 KB |
-| ![](/img/resources/textures_thumbs/SpecularHDR.dds.jpg) | SpecularHDR.env | [take a look](http://playground.babylonjs.com/#CGA05F#32) | 6.12 MB |
-| ![](/img/resources/textures_thumbs/Studio_Softbox_2Umbrellas_cube_specular.dds.jpg) | Studio_Softbox_2Umbrellas_cube_specular.env | [take a look](http://playground.babylonjs.com/#CGA05F#33) | 203 KB |
+| ![](/img/resources/textures_thumbs/SpecularHDR.dds.jpg) | SpecularHDR.env | [take a look](https://playground.babylonjs.com/#CGA05F#32) | 6.12 MB |
+| ![](/img/resources/textures_thumbs/Studio_Softbox_2Umbrellas_cube_specular.dds.jpg) | Studio_Softbox_2Umbrellas_cube_specular.env | [take a look](https://playground.babylonjs.com/#CGA05F#33) | 203 KB |
 
 
 ## Videos
@@ -216,25 +216,25 @@ Textures are stored on `textures/icons/` folder.
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Back.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Back.png | 820 B |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Crop.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Crop.png | 820 B |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Delete.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Delete.png | 800 B |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Dot.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Dot.png | 5.2 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Download.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Download.png | 780 B |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Edit.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Edit.png | 1.25 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/GearIcon.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | GearIcon.png | 7.16 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Icon_Fullscreen.svg' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Icon_Fullscreen.svg | 303 B |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Open.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Open.png | 1 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Pause.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Pause.png | 480 B |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Play.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Play.png | 1 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Redo.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Redo.png | 1.25 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Refresh.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Refresh.png | 1.7 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Save.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Save.png | 780 B |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Settings.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Settings.png | 2.3 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Share.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Share.png | 1.2 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Undo.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Undo.png | 1.2 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Upload.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Upload.png | 780 B |
-| <img src = 'http://www.babylonjs-playground.com/textures/icons/Zoom.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Zoom.png | 1.5 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Back.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Back.png | 820 B |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Crop.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Crop.png | 820 B |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Delete.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Delete.png | 800 B |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Dot.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Dot.png | 5.2 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Download.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Download.png | 780 B |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Edit.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Edit.png | 1.25 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/GearIcon.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | GearIcon.png | 7.16 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Icon_Fullscreen.svg' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Icon_Fullscreen.svg | 303 B |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Open.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Open.png | 1 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Pause.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Pause.png | 480 B |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Play.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Play.png | 1 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Redo.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Redo.png | 1.25 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Refresh.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Refresh.png | 1.7 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Save.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Save.png | 780 B |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Settings.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Settings.png | 2.3 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Share.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Share.png | 1.2 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Undo.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Undo.png | 1.2 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Upload.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Upload.png | 780 B |
+| <img src = 'https://www.babylonjs-playground.com/textures/icons/Zoom.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Zoom.png | 1.5 KB |
 
 ### Misc
 
@@ -242,11 +242,11 @@ Textures are stored on `textures/gui/` folder.
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/gui/backgroundImage.png' width = '128' height = '16' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | backgroundImage.png | 3.1 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/gui/backgroundImage-vertical.png' width = '16' height = '128' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | backgroundImage-vertical.png | 3.5 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/gui/thumb.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | thumb.png | 4.6 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/gui/valueImage.png' width = '128' height = '16' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | valueImage.png | 1.3 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/gui/valueImage-vertical.png' width = '16' height = '128' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | valueImage-vertical.png | 2.1 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/gui/backgroundImage.png' width = '128' height = '16' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | backgroundImage.png | 3.1 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/gui/backgroundImage-vertical.png' width = '16' height = '128' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | backgroundImage-vertical.png | 3.5 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/gui/thumb.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | thumb.png | 4.6 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/gui/valueImage.png' width = '128' height = '16' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | valueImage.png | 1.3 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/gui/valueImage-vertical.png' width = '16' height = '128' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | valueImage-vertical.png | 2.1 KB |
 
 ## FX
 
@@ -254,18 +254,18 @@ Textures are stored on `textures/gui/` folder.
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/impact.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | impact.png | 4 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/nba.png' width = '32' height = '128' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | nba.png | 268 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/impact.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | impact.png | 4 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/nba.png' width = '32' height = '128' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | nba.png | 268 KB |
 
 ### LensFlares
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/flare.png' width = '64' height = '64'> | flare.png | 15 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/lenscolor.png' width = '128' height = '8'> | lenscolor.png | 4 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/lensdirt.jpg' width = '64' height = '64'> | lensdirt.jpg | 19 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/lensflaredirt.png' width = '64' height = '64'> | lensflaredirt.png | 355 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/lensstar.png' width = '64' height = '64'> | lensstar.png | 384 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/flare.png' width = '64' height = '64'> | flare.png | 15 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/lenscolor.png' width = '128' height = '8'> | lenscolor.png | 4 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/lensdirt.jpg' width = '64' height = '64'> | lensdirt.jpg | 19 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/lensflaredirt.png' width = '64' height = '64'> | lensflaredirt.png | 355 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/lensstar.png' width = '64' height = '64'> | lensstar.png | 384 KB |
 
 ### LUT
 
@@ -278,37 +278,37 @@ In the Playground use
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/colorGrade.png' width = '64' height = '8'> | colorGrade.png | 1 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/colorGrade-highContrast.png' width = '64' height = '8'> | colorGrade-highContrast.png | 6 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/colorGrade-inverted.png' width = '64' height = '8'> | colorGrade-inverted.png | 4 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/colorGrade-posterize.png' width = '64' height = '8'> | colorGrade-posterize.png | 2 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/colorGrade.png' width = '64' height = '8'> | colorGrade.png | 1 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/colorGrade-highContrast.png' width = '64' height = '8'> | colorGrade-highContrast.png | 6 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/colorGrade-inverted.png' width = '64' height = '8'> | colorGrade-inverted.png | 4 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/colorGrade-posterize.png' width = '64' height = '8'> | colorGrade-posterize.png | 2 KB |
 
 ### Particles
 
 | Overview | Filename | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/Dot.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Dot.png | 5.2 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/fire.png' width = '64' height = '64'> | fire.jpg | 44 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/Fire_SpriteSheet_8x8.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Fire_SpriteSheet_8x8.png | 170.5 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/Fire_SpriteSheet1_8x8.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Fire_SpriteSheet1_8x8.png | 248.6 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/Fire_SpriteSheet2_8x8.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Fire_SpriteSheet2_8x8.png | 220.7 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/Fire_SpriteSheet3_8x8.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Fire_SpriteSheet3_8x8.png | 240.8 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/FlashParticle.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | FlashParticle.png | 5 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/particle.png' width = '64' height = '64'> | particle.png | 12 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/Rain.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Rain.png | 11 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/Spark.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Spark.png | 5.5 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/sparkle.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | sparkle.png | 93 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/sparkle2.jpg' width = '64' height = '64'> | sparkle2.jpg | 70 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/sparkStretched.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | sparkStretched.png | 6.6 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/sparks.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | sparks.png | 85.8 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Dot.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Dot.png | 5.2 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/fire.png' width = '64' height = '64'> | fire.jpg | 44 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Fire_SpriteSheet_8x8.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Fire_SpriteSheet_8x8.png | 170.5 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Fire_SpriteSheet1_8x8.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Fire_SpriteSheet1_8x8.png | 248.6 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Fire_SpriteSheet2_8x8.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Fire_SpriteSheet2_8x8.png | 220.7 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Fire_SpriteSheet3_8x8.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Fire_SpriteSheet3_8x8.png | 240.8 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/FlashParticle.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | FlashParticle.png | 5 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/particle.png' width = '64' height = '64'> | particle.png | 12 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Rain.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Rain.png | 11 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Spark.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | Spark.png | 5.5 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/sparkle.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | sparkle.png | 93 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/sparkle2.jpg' width = '64' height = '64'> | sparkle2.jpg | 70 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/sparkStretched.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | sparkStretched.png | 6.6 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/sparks.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | sparks.png | 85.8 KB |
 
 ### Sprites
 
 | Overview | Filename | Viewer | Size |
 | :---: | --- | --- |
-| <img src = 'http://www.babylonjs-playground.com/textures/player.png' width = '256' height = '32'> | player.png | [take a look](https://www.babylonjs-playground.com/#D6R7CT#1) | 138 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/Smoke_SpriteSheet_8x8.png' width = '64' height = '64'> | Smoke_SpriteSheet_8x8.png | [take a look](https://www.babylonjs-playground.com/#D6R7CT#2) | 763 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/walk.png' width = '64' height = '64'> | walk.png | [take a look](https://www.babylonjs-playground.com/#D6R7CT#3) | 33 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/player.png' width = '256' height = '32'> | player.png | [take a look](https://www.babylonjs-playground.com/#D6R7CT#1) | 138 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/Smoke_SpriteSheet_8x8.png' width = '64' height = '64'> | Smoke_SpriteSheet_8x8.png | [take a look](https://www.babylonjs-playground.com/#D6R7CT#2) | 763 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/walk.png' width = '64' height = '64'> | walk.png | [take a look](https://www.babylonjs-playground.com/#D6R7CT#3) | 33 KB |
 
 
 ## Misc
@@ -316,21 +316,21 @@ In the Playground use
 | Overview | Filename | Size |
 | :---: | --- | --- |
 | <img src = 'https://assets.babylonjs.com/environments/backgroundGround.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | backgroundGround.png | |
-| <img src = 'http://www.babylonjs-playground.com/textures/DemageFont.png' width = '64' height = '64'> | DemageFont.png | 7 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/invmask.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | invmask.png | 5 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/mask.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | mask.png | 4 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/misc.jpg' width = '64' height = '64'> | misc.jpg | 49 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/mixMap.png' width = '64' height = '64'> | mixMap.png | 131 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/mr.jpg' width = '64' height = '64'> | mr.jpg | 22 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/orient.jpg' width = '64' height = '64'> | orient.jpg | 86 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/roundMask.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | roundMask.png | 8 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/sg.png' width = '64' height = '64'> | sg.png | 643 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/DemageFont.png' width = '64' height = '64'> | DemageFont.png | 7 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/invmask.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | invmask.png | 5 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/mask.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | mask.png | 4 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/misc.jpg' width = '64' height = '64'> | misc.jpg | 49 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/mixMap.png' width = '64' height = '64'> | mixMap.png | 131 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/mr.jpg' width = '64' height = '64'> | mr.jpg | 22 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/orient.jpg' width = '64' height = '64'> | orient.jpg | 86 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/roundMask.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | roundMask.png | 8 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/sg.png' width = '64' height = '64'> | sg.png | 643 KB |
 | <img src = '/img/resources/textures_thumbs/specmap.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | specmap.png | 4.7 MB |
-| <img src = 'http://www.babylonjs-playground.com/textures/spectorjsLayer.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | spectorjsLayer.png | 30 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/specularglossymap.png' width = '64' height = '64'> | specularglossymap.png | 162 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/xStrip.jpg' width = '64' height = '16'> | xStrip.jpg | 28 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/yStrip.jpg' width = '16' height = '64'> | yStrip.jpg | 17 KB |
-| <img src = 'http://www.babylonjs-playground.com/textures/zStrip.jpg' width = '64' height = '16'> | zStrip.jpg | 25 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/spectorjsLayer.png' width = '64' height = '64' style="background-image:url('/img/resources/textures_thumbs/alphaBgd.png');"> | spectorjsLayer.png | 30 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/specularglossymap.png' width = '64' height = '64'> | specularglossymap.png | 162 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/xStrip.jpg' width = '64' height = '16'> | xStrip.jpg | 28 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/yStrip.jpg' width = '16' height = '64'> | yStrip.jpg | 17 KB |
+| <img src = 'https://www.babylonjs-playground.com/textures/zStrip.jpg' width = '64' height = '16'> | zStrip.jpg | 25 KB |
 
 # Further Reading
 


### PR DESCRIPTION
The first time I click on the link I got an error saying that http was not supported. Professor Foster at WWU suggested I change the links to https. 

We also noted that some URLs were playground.babylonjs.com and others were www.babylonjs-playground.com. They appear to be the same content. Which is preferred?  

Comments are welcome!