### PR TITLE
Update How_to_use_MorphTargets.md

### DIFF
--- a/content/How_To/mesh/How_to_use_MorphTargets.md
+++ b/content/How_To/mesh/How_to_use_MorphTargets.md
@@ -102,6 +102,21 @@ manager.addTarget(target3);
 
 At any time, you can remove a target with `manager.removeTarget(target)`
 
+## How to access morph targets in a glTF file
+You can access a morph target influence on a mesh in a glTF file through the [morphTargetManager](https://doc.babylonjs.com/api/classes/babylon.morphtargetmanager#gettarget) which is automatically created for a loaded glTF file containing morph targets. You can see how many influences are present on the mesh by writing to the console.
+
+```
+console.log(mesh.morphTargetManager);
+```
+
+If you want to view or change the value of a morph target influence, it can be accessed by getting the influence from the array in the morphTargetManager by key value.
+
+```
+myInfluence = mesh.morphTargetManager.getTarget(key);
+```
+See the following example for a full playground using morph targets from a glTF file.
+- [Playground using morph targets from a glTF file](https://playground.babylonjs.com/#9CLJEF).
+
 ## List of morphable properties
 
 You can morph the following mesh attributes:


### PR DESCRIPTION
Added documentation and playground example for accessing morph targets from a glTF file.