### PR TITLE
fix import and component name mismatch

### DIFF
--- a/content/resources/Library/BabylonJS_and_ReactJS.md
+++ b/content/resources/Library/BabylonJS_and_ReactJS.md
@@ -95,7 +95,7 @@ Here is a page using our component:
 ```jsx
 import React from 'react';
 import { FreeCamera, Vector3, HemisphericLight, MeshBuilder } from '@babylonjs/core';
-import BabylonScene from './SceneComponent'; // ^^ point to file we created above or 'babylonjs-hook' NPM.
+import SceneComponent from './SceneComponent'; // ^^ point to file we created above or 'babylonjs-hook' NPM.
 import './App.css';
 
 let box;


### PR DESCRIPTION
fix typo #1952 - named default import needs to match in JSX.  The default export can have any name.