### PR TITLE
Update Configuring_the_viewer.md

### DIFF
--- a/content/extensions/Viewer/Configuring_the_viewer.md
+++ b/content/extensions/Viewer/Configuring_the_viewer.md
@@ -100,10 +100,10 @@ Notice that thou the minimal configuration define antialiasing to be `true`, the
 
 Next, the configuration object will be inspected. If it contains a configuration URL, it will be loaded. In our case, the (non-existing) <http://example.com/viewerConfig.json> will be downloaded and appended to the configuration already provided. Notice that this configuration object will overwrite definitions in the current configuration object. So if the JSON file looks like this:
 
-```javascript
+```json
 {
-    scene: {
-        debug: false
+    "scene": {
+        "debug": "false"
     }
 }
 ```


### PR DESCRIPTION
Line 102 to 109 changed to be a valid JSON file. Now users can copy and paste into own local file viewerConfig.json and link to this file, without getting the SyntaxError: JSON.parse: expected property name or '}' at line 2 column 5 of the JSON data