### PR TITLE
Beginner-level WebVR docs should nudge people to WebXR

### DIFF
--- a/content/How_To/camera/WebVR_Camera.md
+++ b/content/How_To/camera/WebVR_Camera.md
@@ -1,3 +1,7 @@
+## WebVR vs WebXR
+
+While the WebVR camera will continue to be supported, it is strongly recommended that projects instead use the [WebXR camera](https://doc.babylonjs.com/how_to/webxr_camera). For more information, check out our [introduction to WebXR](https://doc.babylonjs.com/how_to/introduction_to_webxr).
+
 ## Introduction
 
 Since v2.5 Babylon.js supports WebVR using the WebVRFreeCamera.

--- a/content/How_To/camera/WebVR_Helper.md
+++ b/content/How_To/camera/WebVR_Helper.md
@@ -1,5 +1,9 @@
 # How to use the WebVR experience helper
 
+## WebVR vs WebXR
+
+While the WebVR experience helper will continue to be supported, it is strongly recommended that projects instead use the [WebXR experience helper](https://doc.babylonjs.com/how_to/webxr_experience_helpers). For more information, check out our [introduction to WebXR](https://doc.babylonjs.com/how_to/introduction_to_webxr).
+
 ## Introduction
 
 The WebVR Experience Helper provides a quick way to add WebVR support to a Babylon scene.


### PR DESCRIPTION
As someone relatively new to Babylon.js, my first experience with the docs led me to use the WebVR experience helper instead of the WebXR helper. It took me maybe a month of development before I even realized the WebXR experience helper existed, let alone that I should be using it instead of the older WebVR helper.

I think it would be massively helpful to newcomers if the WebVR experience helper docs had a note nudging new users towards WebXR instead. 

No offense taken if you don't like the copy I've provided or have different thoughts about how this should be communicated. The concrete documentation changes in this PR are merely intended to be a light suggestion in case it's helpful; the high-level feedback I care about here is that beginner-focused WebVR docs should make it clear that WebXR exists and is the path forward.