### PR TITLE
Add Playground examples with custom engines using renderingCanvas instead of renderCanvas

### DIFF
--- a/content/How_To/Physics/Using_The_Physics_Engine.md
+++ b/content/How_To/Physics/Using_The_Physics_Engine.md
@@ -100,6 +100,7 @@ To get reasonably accurate collisions without overloading the physics engine, a 
 1. Loading and adding colliders manually in Babylon: https://playground.babylonjs.com/#FD65RR
 1. Loading and adding collider with joints and pointer interactions: https://playground.babylonjs.com/#DGEP8N
 1. WebVR grabbing and throwing: https://playground.babylonjs.com/#ZNX043
+1. Custom engine with [`deterministicLockstep`](https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep): https://www.babylonjs-playground.com/#3ZW889#7
 
 ### Babylon's physics impostor
 

--- a/content/babylon101/babylon101/First.md
+++ b/content/babylon101/babylon101/First.md
@@ -146,6 +146,8 @@ Finally, add code to call the scene. This enables the engine to continually rend
 
 2. The use of PEP for pointer events is more recent advice, older advice was to use a system called hand.js. Both work, although hand.js is no longer maintained. You may still find references to hand.js in the documentation.
 
+3. If you want to define your own engine in a Playground, define a function `createEngine` that returns the engine. This is useful when using your [physics engine](https://doc.babylonjs.com/how_to/using_the_physics_engine) of choice with a customized engine in a Playground. Example: https://www.babylonjs-playground.com/#WG9OY#1830.
+
 # Next Step
 
 Now you are ready to go further and learn how to create more shapes like spheres, cylinders, boxes, etc. by visiting [Set Shapes](/babylon101/Discover_Basic_Elements)

--- a/typedoc/babylon.d.ts
+++ b/typedoc/babylon.d.ts
@@ -903,88 +903,88 @@ declare module BABYLON {
         static readonly MATERIAL_CounterClockWiseSideOrientation: number;
         /**
          * Nothing
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_NothingTrigger: number;
         /**
          * On pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnPickTrigger: number;
         /**
          * On left pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnLeftPickTrigger: number;
         /**
          * On right pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnRightPickTrigger: number;
         /**
          * On center pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnCenterPickTrigger: number;
         /**
          * On pick down
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnPickDownTrigger: number;
         /**
          * On double pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnDoublePickTrigger: number;
         /**
          * On pick up
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnPickUpTrigger: number;
         /**
          * On pick out.
          * This trigger will only be raised if you also declared a OnPickDown
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnPickOutTrigger: number;
         /**
          * On long press
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnLongPressTrigger: number;
         /**
          * On pointer over
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnPointerOverTrigger: number;
         /**
          * On pointer out
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnPointerOutTrigger: number;
         /**
          * On every frame
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnEveryFrameTrigger: number;
         /**
          * On intersection enter
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnIntersectionEnterTrigger: number;
         /**
          * On intersection exit
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnIntersectionExitTrigger: number;
         /**
          * On key down
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnKeyDownTrigger: number;
         /**
          * On key up
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly ACTION_OnKeyUpTrigger: number;
         /**
@@ -1049,6 +1049,22 @@ declare module BABYLON {
          * Detailled logging while loading
          */
         static readonly SCENELOADER_DETAILED_LOGGING: number;
+        /**
+         * Prepass texture index for color
+         */
+        static readonly PREPASS_COLOR_INDEX: number;
+        /**
+         * Prepass texture index for irradiance
+         */
+        static readonly PREPASS_IRRADIANCE_INDEX: number;
+        /**
+         * Prepass texture index for depth + normal
+         */
+        static readonly PREPASS_DEPTHNORMAL_INDEX: number;
+        /**
+         * Prepass texture index for albedo
+         */
+        static readonly PREPASS_ALBEDO_INDEX: number;
     }
 }
 declare module BABYLON {
@@ -1063,9 +1079,10 @@ declare module BABYLON {
         /**
          * This returns if the loader support the current file information.
          * @param extension defines the file extension of the file being loaded
+         * @param mimeType defines the optional mime type of the file being loaded
          * @returns true if the loader can load the specified file
          */
-        canLoad(extension: string): boolean;
+        canLoad(extension: string, mimeType?: string): boolean;
         /**
          * Uploads the cube texture data to the WebGL texture. It has already been bound.
          * @param data contains the texture data
@@ -1257,7 +1274,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to enable access to offline support
-     * @see http://doc.babylonjs.com/how_to/caching_resources_in_indexeddb
+     * @see https://doc.babylonjs.com/how_to/caching_resources_in_indexeddb
      */
     export interface IOfflineProvider {
         /**
@@ -1520,7 +1537,7 @@ declare module BABYLON {
      * @hidden
      */
     export interface IMatrixLike {
-        toArray(): DeepImmutable<Float32Array>;
+        toArray(): DeepImmutable<Float32Array | Array<number>>;
         updateFlag: int;
     }
     /**
@@ -2017,6 +2034,21 @@ declare module BABYLON {
          * @returns the signed distance between the plane defined by the normal vector at the "origin"" point and the given other point.
          */
         static SignedDistanceToPlaneFromPositionAndNormal(origin: DeepImmutable<Vector3>, normal: DeepImmutable<Vector3>, point: DeepImmutable<Vector3>): number;
+    }
+}
+declare module BABYLON {
+    /** @hidden */
+    export class PerformanceConfigurator {
+        /** @hidden */
+        static MatrixUse64Bits: boolean;
+        /** @hidden */
+        static MatrixTrackPrecisionChange: boolean;
+        /** @hidden */
+        static MatrixCurrentType: any;
+        /** @hidden */
+        static MatrixTrackedMatrices: Array<any> | null;
+        /** @hidden */
+        static SetMatrixPrecision(use64bits: boolean): void;
     }
 }
 declare module BABYLON {
@@ -3590,7 +3622,7 @@ declare module BABYLON {
     /**
      * Class used to store quaternion data
      * @see https://en.wikipedia.org/wiki/Quaternion
-     * @see http://doc.babylonjs.com/features/position,_rotation,_scaling
+     * @see https://doc.babylonjs.com/features/position,_rotation,_scaling
      */
     export class Quaternion {
         /** @hidden */
@@ -3992,6 +4024,10 @@ declare module BABYLON {
      * Class used to store matrix data (4x4)
      */
     export class Matrix {
+        /**
+         * Gets the precision of matrix computations
+         */
+        static get Use64Bits(): boolean;
         private static _updateFlagSeed;
         private static _identityReadOnly;
         private _isIdentity;
@@ -4008,7 +4044,7 @@ declare module BABYLON {
         /**
          * Gets the internal data of the matrix
          */
-        get m(): DeepImmutable<Float32Array>;
+        get m(): DeepImmutable<Float32Array | Array<number>>;
         /** @hidden */
         _markAsUpdated(): void;
         /** @hidden */
@@ -4033,15 +4069,15 @@ declare module BABYLON {
          */
         determinant(): number;
         /**
-         * Returns the matrix as a Float32Array
+         * Returns the matrix as a Float32Array or Array<number>
          * @returns the matrix underlying array
          */
-        toArray(): DeepImmutable<Float32Array>;
+        toArray(): DeepImmutable<Float32Array | Array<number>>;
         /**
-         * Returns the matrix as a Float32Array
+         * Returns the matrix as a Float32Array or Array<number>
         * @returns the matrix underlying array.
         */
-        asArray(): DeepImmutable<Float32Array>;
+        asArray(): DeepImmutable<Float32Array | Array<number>>;
         /**
          * Inverts the current matrix in place
          * @returns the current inverted matrix
@@ -4147,7 +4183,7 @@ declare module BABYLON {
          * @param offset defines the offset in the target array where to start storing values
          * @returns the current matrix
          */
-        copyToArray(array: Float32Array, offset?: number): Matrix;
+        copyToArray(array: Float32Array | Array<number>, offset?: number): Matrix;
         /**
          * Sets the given matrix "result" with the multiplication result of the current Matrix and the given one
          * @param other defines the second operand
@@ -4162,7 +4198,7 @@ declare module BABYLON {
          * @param offset defines the offset in the target array where to start storing values
          * @returns the current matrix
          */
-        multiplyToArray(other: DeepImmutable<Matrix>, result: Float32Array, offset: number): Matrix;
+        multiplyToArray(other: DeepImmutable<Matrix>, result: Float32Array | Array<number>, offset: number): Matrix;
         /**
          * Check equality between this matrix and a second one
          * @param value defines the second matrix to compare
@@ -4291,7 +4327,7 @@ declare module BABYLON {
          * @param scale defines the scaling factor
          * @param result defines the target matrix
          */
-        static FromFloat32ArrayToRefScaled(array: DeepImmutable<Float32Array>, offset: number, scale: number, result: Matrix): void;
+        static FromFloat32ArrayToRefScaled(array: DeepImmutable<Float32Array | Array<number>>, offset: number, scale: number, result: Matrix): void;
         /**
          * Gets an identity matrix that must not be updated
          */
@@ -4437,7 +4473,7 @@ declare module BABYLON {
          * Creates a rotation matrix
          * @param yaw defines the yaw angle in radians (Y axis)
          * @param pitch defines the pitch angle in radians (X axis)
-         * @param roll defines the roll angle in radians (X axis)
+         * @param roll defines the roll angle in radians (Z axis)
          * @returns the new rotation matrix
          */
         static RotationYawPitchRoll(yaw: number, pitch: number, roll: number): Matrix;
@@ -4445,7 +4481,7 @@ declare module BABYLON {
          * Creates a rotation matrix and stores it in a given matrix
          * @param yaw defines the yaw angle in radians (Y axis)
          * @param pitch defines the pitch angle in radians (X axis)
-         * @param roll defines the roll angle in radians (X axis)
+         * @param roll defines the roll angle in radians (Z axis)
          * @param result defines the target matrix
          */
         static RotationYawPitchRollToRef(yaw: number, pitch: number, roll: number, result: Matrix): void;
@@ -4714,13 +4750,13 @@ declare module BABYLON {
          * @param matrix defines the matrix to use
          * @returns a new Float32Array array with 4 elements : the 2x2 matrix extracted from the given matrix
          */
-        static GetAsMatrix2x2(matrix: DeepImmutable<Matrix>): Float32Array;
+        static GetAsMatrix2x2(matrix: DeepImmutable<Matrix>): Float32Array | Array<number>;
         /**
          * Extracts a 3x3 matrix from a given matrix and store the result in a Float32Array
          * @param matrix defines the matrix to use
          * @returns a new Float32Array array with 9 elements : the 3x3 matrix extracted from the given matrix
          */
-        static GetAsMatrix3x3(matrix: DeepImmutable<Matrix>): Float32Array;
+        static GetAsMatrix3x3(matrix: DeepImmutable<Matrix>): Float32Array | Array<number>;
         /**
          * Compute the transpose of a given matrix
          * @param matrix defines the matrix to transpose
@@ -4817,9 +4853,9 @@ declare module BABYLON {
          */
         radians(): number;
         /**
-         * Gets a new Angle object valued with the angle value in radians between the two given vectors
-         * @param a defines first vector
-         * @param b defines second vector
+         * Gets a new Angle object valued with the gradient angle, in radians, of the line joining two points
+         * @param a defines first point as the origin
+         * @param b defines point
          * @returns a new Angle
          */
         static BetweenTwoPoints(a: DeepImmutable<Vector2>, b: DeepImmutable<Vector2>): Angle;
@@ -5170,7 +5206,7 @@ declare module BABYLON {
     /**
      * This represents the main contract an easing function should follow.
      * Easing functions are used throughout the animation system.
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export interface IEasingFunction {
         /**
@@ -5185,7 +5221,7 @@ declare module BABYLON {
     }
     /**
      * Base class used for every default easing function.
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class EasingFunction implements IEasingFunction {
         /**
@@ -5226,7 +5262,7 @@ declare module BABYLON {
     /**
      * Easing function with a circle shape (see link below).
      * @see https://easings.net/#easeInCirc
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class CircleEase extends EasingFunction implements IEasingFunction {
         /** @hidden */
@@ -5235,7 +5271,7 @@ declare module BABYLON {
     /**
      * Easing function with a ease back shape (see link below).
      * @see https://easings.net/#easeInBack
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class BackEase extends EasingFunction implements IEasingFunction {
         /** Defines the amplitude of the function */
@@ -5254,7 +5290,7 @@ declare module BABYLON {
     /**
      * Easing function with a bouncing shape (see link below).
      * @see https://easings.net/#easeInBounce
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class BounceEase extends EasingFunction implements IEasingFunction {
         /** Defines the number of bounces */
@@ -5278,7 +5314,7 @@ declare module BABYLON {
     /**
      * Easing function with a power of 3 shape (see link below).
      * @see https://easings.net/#easeInCubic
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class CubicEase extends EasingFunction implements IEasingFunction {
         /** @hidden */
@@ -5287,7 +5323,7 @@ declare module BABYLON {
     /**
      * Easing function with an elastic shape (see link below).
      * @see https://easings.net/#easeInElastic
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class ElasticEase extends EasingFunction implements IEasingFunction {
         /** Defines the number of oscillations*/
@@ -5311,7 +5347,7 @@ declare module BABYLON {
     /**
      * Easing function with an exponential shape (see link below).
      * @see https://easings.net/#easeInExpo
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class ExponentialEase extends EasingFunction implements IEasingFunction {
         /** Defines the exponent of the function */
@@ -5330,7 +5366,7 @@ declare module BABYLON {
     /**
      * Easing function with a power shape (see link below).
      * @see https://easings.net/#easeInQuad
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class PowerEase extends EasingFunction implements IEasingFunction {
         /** Defines the power of the function */
@@ -5349,7 +5385,7 @@ declare module BABYLON {
     /**
      * Easing function with a power of 2 shape (see link below).
      * @see https://easings.net/#easeInQuad
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class QuadraticEase extends EasingFunction implements IEasingFunction {
         /** @hidden */
@@ -5358,7 +5394,7 @@ declare module BABYLON {
     /**
      * Easing function with a power of 4 shape (see link below).
      * @see https://easings.net/#easeInQuart
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class QuarticEase extends EasingFunction implements IEasingFunction {
         /** @hidden */
@@ -5367,7 +5403,7 @@ declare module BABYLON {
     /**
      * Easing function with a power of 5 shape (see link below).
      * @see https://easings.net/#easeInQuint
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class QuinticEase extends EasingFunction implements IEasingFunction {
         /** @hidden */
@@ -5376,7 +5412,7 @@ declare module BABYLON {
     /**
      * Easing function with a sin shape (see link below).
      * @see https://easings.net/#easeInSine
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class SineEase extends EasingFunction implements IEasingFunction {
         /** @hidden */
@@ -5385,7 +5421,7 @@ declare module BABYLON {
     /**
      * Easing function with a bezier shape (see link below).
      * @see http://cubic-bezier.com/#.17,.67,.83,.67
-     * @see http://doc.babylonjs.com/babylon101/animations#easing-functions
+     * @see https://doc.babylonjs.com/babylon101/animations#easing-functions
      */
     export class BezierCurveEase extends EasingFunction implements IEasingFunction {
         /** Defines the x component of the start tangent in the bezier curve */
@@ -6313,7 +6349,7 @@ declare module BABYLON {
     /**
      * This represents the input manager used within a camera.
      * It helps dealing with all the different kind of input attached to a camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class CameraInputsManager<TCamera extends Camera> {
         /**
@@ -6345,7 +6381,7 @@ declare module BABYLON {
         constructor(camera: TCamera);
         /**
          * Add an input method to a camera
-         * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+         * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
          * @param input camera input method
          */
         add(input: ICameraInput<TCamera>): void;
@@ -7214,21 +7250,21 @@ declare module BABYLON {
         interface ThinEngine {
             /**
              * Create an uniform buffer
-             * @see http://doc.babylonjs.com/features/webgl2#uniform-buffer-objets
+             * @see https://doc.babylonjs.com/features/webgl2#uniform-buffer-objets
              * @param elements defines the content of the uniform buffer
              * @returns the webGL uniform buffer
              */
             createUniformBuffer(elements: FloatArray): DataBuffer;
             /**
              * Create a dynamic uniform buffer
-             * @see http://doc.babylonjs.com/features/webgl2#uniform-buffer-objets
+             * @see https://doc.babylonjs.com/features/webgl2#uniform-buffer-objets
              * @param elements defines the content of the uniform buffer
              * @returns the webGL uniform buffer
              */
             createDynamicUniformBuffer(elements: FloatArray): DataBuffer;
             /**
              * Update an existing uniform buffer
-             * @see http://doc.babylonjs.com/features/webgl2#uniform-buffer-objets
+             * @see https://doc.babylonjs.com/features/webgl2#uniform-buffer-objets
              * @param uniformBuffer defines the target uniform buffer
              * @param elements defines the content to update
              * @param offset defines the offset in the uniform buffer where update should start
@@ -7716,7 +7752,7 @@ declare module BABYLON {
         /**
          * Gets or sets the center of the bounding box associated with the cube texture.
          * It must define where the camera used to render the texture was set
-         * @see http://doc.babylonjs.com/how_to/reflect#using-local-cubemap-mode
+         * @see https://doc.babylonjs.com/how_to/reflect#using-local-cubemap-mode
          */
         boundingBoxPosition: Vector3;
         private _boundingBoxSize;
@@ -7729,7 +7765,7 @@ declare module BABYLON {
         set boundingBoxSize(value: Vector3);
         /**
          * Returns the bounding box size
-         * @see http://doc.babylonjs.com/how_to/reflect#using-local-cubemap-mode
+         * @see https://doc.babylonjs.com/how_to/reflect#using-local-cubemap-mode
          */
         get boundingBoxSize(): Vector3;
         protected _rotationY: number;
@@ -9340,7 +9376,7 @@ declare module BABYLON {
     }
     /**
      * The action to be carried out following a trigger
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions#available-actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions#available-actions
      */
     export class Action implements IAction {
         /** the trigger, with or without parameters, for the action */
@@ -9431,7 +9467,7 @@ declare module BABYLON {
          * Internal only
          * @hidden
          */
-        static _GetTargetProperty: (target: Node | Scene) => {
+        static _GetTargetProperty: (target: Scene | Node) => {
             name: string;
             targetType: string;
             value: string;
@@ -9651,7 +9687,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * This defines an action responsible to toggle a boolean once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class SwitchBooleanAction extends Action {
         /**
@@ -9685,7 +9721,7 @@ declare module BABYLON {
     /**
      * This defines an action responsible to set a the state field of the target
      *  to a desired value once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class SetStateAction extends Action {
         /**
@@ -9715,7 +9751,7 @@ declare module BABYLON {
     /**
      * This defines an action responsible to set a property of the target
      *  to a desired value once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class SetValueAction extends Action {
         /**
@@ -9754,7 +9790,7 @@ declare module BABYLON {
     /**
      * This defines an action responsible to increment the target value
      *  to a desired value once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class IncrementValueAction extends Action {
         /**
@@ -9792,7 +9828,7 @@ declare module BABYLON {
     }
     /**
      * This defines an action responsible to start an animation once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class PlayAnimationAction extends Action {
         /**
@@ -9833,7 +9869,7 @@ declare module BABYLON {
     }
     /**
      * This defines an action responsible to stop an animation once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class StopAnimationAction extends Action {
         private _target;
@@ -9859,7 +9895,7 @@ declare module BABYLON {
     }
     /**
      * This defines an action responsible that does nothing once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class DoNothingAction extends Action {
         /**
@@ -9881,7 +9917,7 @@ declare module BABYLON {
     }
     /**
      * This defines an action responsible to trigger several actions once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class CombineAction extends Action {
         /**
@@ -9910,7 +9946,7 @@ declare module BABYLON {
     }
     /**
      * This defines an action responsible to run code (external event) once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class ExecuteCodeAction extends Action {
         /**
@@ -9931,7 +9967,7 @@ declare module BABYLON {
     }
     /**
      * This defines an action responsible to set the parent property of the target once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class SetParentAction extends Action {
         private _parent;
@@ -9962,93 +9998,93 @@ declare module BABYLON {
     /**
      * Action Manager manages all events to be triggered on a given mesh or the global scene.
      * A single scene can have many Action Managers to handle predefined actions on specific meshes.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class ActionManager extends AbstractActionManager {
         /**
          * Nothing
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly NothingTrigger: number;
         /**
          * On pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnPickTrigger: number;
         /**
          * On left pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnLeftPickTrigger: number;
         /**
          * On right pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnRightPickTrigger: number;
         /**
          * On center pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnCenterPickTrigger: number;
         /**
          * On pick down
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnPickDownTrigger: number;
         /**
          * On double pick
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnDoublePickTrigger: number;
         /**
          * On pick up
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnPickUpTrigger: number;
         /**
          * On pick out.
          * This trigger will only be raised if you also declared a OnPickDown
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnPickOutTrigger: number;
         /**
          * On long press
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnLongPressTrigger: number;
         /**
          * On pointer over
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnPointerOverTrigger: number;
         /**
          * On pointer out
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnPointerOutTrigger: number;
         /**
          * On every frame
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnEveryFrameTrigger: number;
         /**
          * On intersection enter
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnIntersectionEnterTrigger: number;
         /**
          * On intersection exit
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnIntersectionExitTrigger: number;
         /**
          * On key down
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnKeyDownTrigger: number;
         /**
          * On key up
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions#triggers
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions#triggers
          */
         static readonly OnKeyUpTrigger: number;
         private _scene;
@@ -10141,7 +10177,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to represent a sprite
-     * @see http://doc.babylonjs.com/babylon101/sprites
+     * @see https://doc.babylonjs.com/babylon101/sprites
      */
     export class Sprite implements IAnimatable {
         /** defines the name */
@@ -10522,6 +10558,7 @@ declare module BABYLON {
         static readonly NAME_GAMEPAD: string;
         static readonly NAME_SIMPLIFICATIONQUEUE: string;
         static readonly NAME_GEOMETRYBUFFERRENDERER: string;
+        static readonly NAME_PREPASSRENDERER: string;
         static readonly NAME_DEPTHRENDERER: string;
         static readonly NAME_POSTPROCESSRENDERPIPELINEMANAGER: string;
         static readonly NAME_SPRITE: string;
@@ -10538,6 +10575,7 @@ declare module BABYLON {
         static readonly STEP_CAMERADRAWRENDERTARGET_EFFECTLAYER: number;
         static readonly STEP_BEFORECAMERADRAW_EFFECTLAYER: number;
         static readonly STEP_BEFORECAMERADRAW_LAYER: number;
+        static readonly STEP_BEFORECAMERADRAW_PREPASS: number;
         static readonly STEP_BEFORERENDERTARGETDRAW_LAYER: number;
         static readonly STEP_BEFORERENDERINGMESH_OUTLINE: number;
         static readonly STEP_AFTERRENDERINGMESH_OUTLINE: number;
@@ -10551,12 +10589,14 @@ declare module BABYLON {
         static readonly STEP_AFTERCAMERADRAW_LENSFLARESYSTEM: number;
         static readonly STEP_AFTERCAMERADRAW_EFFECTLAYER_DRAW: number;
         static readonly STEP_AFTERCAMERADRAW_LAYER: number;
+        static readonly STEP_AFTERCAMERADRAW_PREPASS: number;
         static readonly STEP_AFTERRENDER_AUDIO: number;
         static readonly STEP_GATHERRENDERTARGETS_DEPTHRENDERER: number;
         static readonly STEP_GATHERRENDERTARGETS_GEOMETRYBUFFERRENDERER: number;
         static readonly STEP_GATHERRENDERTARGETS_SHADOWGENERATOR: number;
         static readonly STEP_GATHERRENDERTARGETS_POSTPROCESSRENDERPIPELINEMANAGER: number;
         static readonly STEP_GATHERACTIVECAMERARENDERTARGETS_DEPTHRENDERER: number;
+        static readonly STEP_BEFORECLEARSTAGE_PREPASS: number;
         static readonly STEP_POINTERMOVE_SPRITE: number;
         static readonly STEP_POINTERDOWN_SPRITE: number;
         static readonly STEP_POINTERUP_SPRITE: number;
@@ -10703,7 +10743,7 @@ declare module BABYLON {
             _tempSpritePickingRay: Nullable<Ray>;
             /**
              * All of the sprite managers added to this scene
-             * @see http://doc.babylonjs.com/babylon101/sprites
+             * @see https://doc.babylonjs.com/babylon101/sprites
              */
             spriteManagers: Array<ISpriteManager>;
             /**
@@ -10861,7 +10901,7 @@ declare module BABYLON {
         scene: Scene;
         /**
          * Specifies the rendering group id for this mesh (0 by default)
-         * @see http://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered#rendering-groups
+         * @see https://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered#rendering-groups
          */
         renderingGroupId: number;
         /**
@@ -10900,7 +10940,7 @@ declare module BABYLON {
     }
     /**
      * Class used to manage multiple sprites on the same spritesheet
-     * @see http://doc.babylonjs.com/babylon101/sprites
+     * @see https://doc.babylonjs.com/babylon101/sprites
      */
     export class SpriteManager implements ISpriteManager {
         /** defines the manager's name */
@@ -11485,7 +11525,7 @@ declare module BABYLON {
         interface AbstractScene {
             /**
              * The list of procedural textures added to the scene
-             * @see http://doc.babylonjs.com/how_to/how_to_use_procedural_textures
+             * @see https://doc.babylonjs.com/how_to/how_to_use_procedural_textures
              */
             proceduralTextures: Array<ProceduralTexture>;
         }
@@ -11545,7 +11585,7 @@ declare module BABYLON {
     /**
      * Procedural texturing is a way to programmatically create a texture. There are 2 types of procedural textures: code-only, and code that references some classic 2D images, sometimes calmpler' images.
      * This is the base class of any Procedural texture and contains most of the shareable code.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_procedural_textures
+     * @see https://doc.babylonjs.com/how_to/how_to_use_procedural_textures
      */
     export class ProceduralTexture extends Texture {
         isCube: boolean;
@@ -11601,7 +11641,7 @@ declare module BABYLON {
          * Instantiates a new procedural texture.
          * Procedural texturing is a way to programmatically create a texture. There are 2 types of procedural textures: code-only, and code that references some classic 2D images, sometimes called 'refMaps' or 'sampler' images.
          * This is the base class of any Procedural texture and contains most of the shareable code.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_procedural_textures
+         * @see https://doc.babylonjs.com/how_to/how_to_use_procedural_textures
          * @param name  Define the name of the texture
          * @param size Define the size of the texture to create
          * @param fragment Define the fragment shader to use to generate the texture or null if it is defined later
@@ -12414,7 +12454,7 @@ declare module BABYLON {
         private _rampGradientsTexture;
         private _useRampGradients;
         /** Gets or sets a boolean indicating that ramp gradients must be used
-         * @see http://doc.babylonjs.com/babylon101/particles#ramp-gradients
+         * @see https://doc.babylonjs.com/babylon101/particles#ramp-gradients
          */
         get useRampGradients(): boolean;
         set useRampGradients(value: boolean);
@@ -14291,7 +14331,7 @@ declare module BABYLON {
          */
         getRampGradients(): Nullable<Array<Color3Gradient>>;
         /** Gets or sets a boolean indicating that ramp gradients must be used
-         * @see http://doc.babylonjs.com/babylon101/particles#ramp-gradients
+         * @see https://doc.babylonjs.com/babylon101/particles#ramp-gradients
          */
         useRampGradients: boolean;
         /**
@@ -14896,7 +14936,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to store bone information
-     * @see http://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons
+     * @see https://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons
      */
     export class Bone extends Node {
         /**
@@ -15581,13 +15621,13 @@ declare module BABYLON {
         reset(): void;
         /**
          * Allows the animatable to blend with current running animations
-         * @see http://doc.babylonjs.com/babylon101/animations#animation-blending
+         * @see https://doc.babylonjs.com/babylon101/animations#animation-blending
          * @param blendingSpeed defines the blending speed to use
          */
         enableBlending(blendingSpeed: number): void;
         /**
          * Disable animation blending
-         * @see http://doc.babylonjs.com/babylon101/animations#animation-blending
+         * @see https://doc.babylonjs.com/babylon101/animations#animation-blending
          */
         disableBlending(): void;
         /**
@@ -15754,7 +15794,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to handle skinning animations
-     * @see http://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons
+     * @see https://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons
      */
     export class Skeleton implements IAnimatable {
         /** defines the skeleton name */
@@ -15962,7 +16002,7 @@ declare module BABYLON {
         /**
          * Enable animation blending for this skeleton
          * @param blendingSpeed defines the blending speed to apply
-         * @see http://doc.babylonjs.com/babylon101/animations#animation-blending
+         * @see https://doc.babylonjs.com/babylon101/animations#animation-blending
          */
         enableBlending(blendingSpeed?: number): void;
         /**
@@ -16053,7 +16093,7 @@ declare module BABYLON {
         get sourceMesh(): Mesh;
         /**
          * Creates a new InstancedMesh object from the mesh model.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_instances
+         * @see https://doc.babylonjs.com/how_to/how_to_use_instances
          * @param name defines the name of the new instance
          * @returns a new InstancedMesh
          */
@@ -16256,7 +16296,7 @@ declare module BABYLON {
      *
      * This returned material effects how the mesh will look based on the code in the shaders.
      *
-     * @see http://doc.babylonjs.com/how_to/shader_material
+     * @see https://doc.babylonjs.com/how_to/shader_material
      */
     export class ShaderMaterial extends Material {
         private _shaderPath;
@@ -16293,7 +16333,7 @@ declare module BABYLON {
          * Instantiate a new shader material.
          * The ShaderMaterial object has the necessary methods to pass data from your scene to the Vertex and Fragment Shaders and returns a material that can be applied to any mesh.
          * This returned material effects how the mesh will look based on the code in the shaders.
-         * @see http://doc.babylonjs.com/how_to/shader_material
+         * @see https://doc.babylonjs.com/how_to/shader_material
          * @param name Define the name of the material in the scene
          * @param scene Define the scene the material belongs to
          * @param shaderPath Defines  the route to the shader code in one of three ways:
@@ -16440,14 +16480,14 @@ declare module BABYLON {
          * @param value Define the value to give to the uniform
          * @return the material itself allowing "fluent" like uniform updates
          */
-        setMatrix3x3(name: string, value: Float32Array): ShaderMaterial;
+        setMatrix3x3(name: string, value: Float32Array | Array<number>): ShaderMaterial;
         /**
          * Set a mat2 in the shader from a Float32Array.
          * @param name Define the name of the uniform as defined in the shader
          * @param value Define the value to give to the uniform
          * @return the material itself allowing "fluent" like uniform updates
          */
-        setMatrix2x2(name: string, value: Float32Array): ShaderMaterial;
+        setMatrix2x2(name: string, value: Float32Array | Array<number>): ShaderMaterial;
         /**
          * Set a vec2 array in the shader from a number array.
          * @param name Define the name of the uniform as defined in the shader
@@ -16661,7 +16701,7 @@ declare module BABYLON {
         clone(name: string, newParent?: Nullable<Node>, doNotCloneChildren?: boolean): LinesMesh;
         /**
          * Creates a new InstancedLinesMesh object from the mesh model.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_instances
+         * @see https://doc.babylonjs.com/how_to/how_to_use_instances
          * @param name defines the name of the new instance
          * @returns a new InstancedLinesMesh
          */
@@ -16754,6 +16794,41 @@ declare module BABYLON {
         customInstances: SmartArray<Matrix>;
     }
     /**
+     * Defines the additional options of the edges renderer
+     */
+    export interface IEdgesRendererOptions {
+        /**
+         * Gets or sets a boolean indicating that the alternate edge finder algorithm must be used
+         * If not defined, the default value is true
+         */
+        useAlternateEdgeFinder?: boolean;
+        /**
+         * Gets or sets a boolean indicating that the vertex merger fast processing must be used.
+         * If not defined, the default value is true.
+         * You should normally leave it undefined (or set it to true), except if you see some artifacts in the edges rendering (can happen with complex geometries)
+         * This option is used only if useAlternateEdgeFinder = true
+         */
+        useFastVertexMerger?: boolean;
+        /**
+         * During edges processing, the vertices are merged if they are close enough: epsilonVertexMerge is the limit whithin which vertices are considered to be equal.
+         * The default value is 1e-6
+         * This option is used only if useAlternateEdgeFinder = true
+         */
+        epsilonVertexMerge?: number;
+        /**
+         * Gets or sets a boolean indicating that tessellation should be applied before finding the edges. You may need to activate this option if your geometry is a bit
+         * unusual, like having a vertex of a triangle in-between two vertices of an edge of another triangle. It happens often when using CSG to construct meshes.
+         * This option is used only if useAlternateEdgeFinder = true
+         */
+        applyTessellation?: boolean;
+        /**
+         * The limit under which 3 vertices are considered to be aligned. 3 vertices PQR are considered aligned if distance(PQ) + distance(QR) - distance(PR) < epsilonVertexAligned
+         * The default value is 1e-6
+         * This option is used only if useAlternateEdgeFinder = true
+         */
+        epsilonVertexAligned?: number;
+    }
+    /**
      * This class is used to generate edges of the mesh that could then easily be rendered in a scene.
      */
     export class EdgesRenderer implements IEdgesRenderer {
@@ -16780,6 +16855,7 @@ declare module BABYLON {
             [key: string]: Nullable<VertexBuffer>;
         };
         protected _checkVerticesInsteadOfIndices: boolean;
+        protected _options: Nullable<IEdgesRendererOptions>;
         private _meshRebuildObserver;
         private _meshDisposeObserver;
         /** Gets or sets a boolean indicating if the edgesRenderer is active */
@@ -16794,10 +16870,11 @@ declare module BABYLON {
          * Beware when you use this class with complex objects as the adjacencies computation can be really long
          * @param  source Mesh used to create edges
          * @param  epsilon sum of angles in adjacency to check for edge
-         * @param  checkVerticesInsteadOfIndices bases the edges detection on vertices vs indices
+         * @param  checkVerticesInsteadOfIndices bases the edges detection on vertices vs indices. Note that this parameter is not used if options.useAlternateEdgeFinder = true
          * @param  generateEdgesLines - should generate Lines or only prepare resources.
+         * @param  options The options to apply when generating the edges
          */
-        constructor(source: AbstractMesh, epsilon?: number, checkVerticesInsteadOfIndices?: boolean, generateEdgesLines?: boolean);
+        constructor(source: AbstractMesh, epsilon?: number, checkVerticesInsteadOfIndices?: boolean, generateEdgesLines?: boolean, options?: IEdgesRendererOptions);
         protected _prepareRessources(): void;
         /** @hidden */
         _rebuild(): void;
@@ -16822,6 +16899,11 @@ declare module BABYLON {
          * @protected
          */
         protected createLine(p0: Vector3, p1: Vector3, offset: number): void;
+        /**
+         * See https://playground.babylonjs.com/#R3JR6V#1 for a visual display of the algorithm
+         */
+        private _tessellateTriangle;
+        private _generateEdgesLinesAlternate;
         /**
          * Generates lines edges from adjacencjes
          * @private
@@ -18070,7 +18152,7 @@ declare module BABYLON {
     /**
      * A target camera takes a mesh or position as a target and continues to look at it while it moves.
      * This is the base of the follow, arc rotate cameras and Free camera
-     * @see http://doc.babylonjs.com/features/cameras
+     * @see https://doc.babylonjs.com/features/cameras
      */
     export class TargetCamera extends Camera {
         private static _RigCamTransformMatrix;
@@ -18145,7 +18227,7 @@ declare module BABYLON {
         /**
          * Instantiates a target camera that takes a mesh or position as a target and continues to look at it while it moves.
          * This is the base of the follow, arc rotate cameras and Free camera
-         * @see http://doc.babylonjs.com/features/cameras
+         * @see https://doc.babylonjs.com/features/cameras
          * @param name Defines the name of the camera in the scene
          * @param position Defines the start position of the camera in the scene
          * @param scene Defines the scene the camera belongs to
@@ -18304,7 +18386,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the keyboard inputs to control the movement of a free camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
         /**
@@ -18503,7 +18585,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the mouse inputs to control the movement of a free camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FreeCameraMouseInput implements ICameraInput<FreeCamera> {
         /**
@@ -18540,7 +18622,7 @@ declare module BABYLON {
         _allowCameraRotation: boolean;
         /**
          * Manage the mouse inputs to control the movement of a free camera.
-         * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+         * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
          * @param touchEnabled Defines if touch is enabled or not
          */
         constructor(
@@ -18579,7 +18661,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the touch inputs to control the movement of a free camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
         /**
@@ -18634,7 +18716,7 @@ declare module BABYLON {
     /**
      * Default Inputs manager for the FreeCamera.
      * It groups all the default supported inputs for ease of use.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FreeCameraInputsManager extends CameraInputsManager<FreeCamera> {
         /**
@@ -18677,13 +18759,13 @@ declare module BABYLON {
     /**
      * This represents a free type of camera. It can be useful in First Person Shooter game for instance.
      * Please consider using the new UniversalCamera instead as it adds more functionality like the gamepad.
-     * @see http://doc.babylonjs.com/features/cameras#universal-camera
+     * @see https://doc.babylonjs.com/features/cameras#universal-camera
      */
     export class FreeCamera extends TargetCamera {
         /**
          * Define the collision ellipsoid of the camera.
          * This is helpful to simulate a camera body like the player body around the camera
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity#arcrotatecamera
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity#arcrotatecamera
          */
         ellipsoid: Vector3;
         /**
@@ -18761,7 +18843,7 @@ declare module BABYLON {
          * Instantiates a Free Camera.
          * This represents a free type of camera. It can be useful in First Person Shooter game for instance.
          * Please consider using the new UniversalCamera instead as it adds more functionality like touch to this camera.
-         * @see http://doc.babylonjs.com/features/cameras#universal-camera
+         * @see https://doc.babylonjs.com/features/cameras#universal-camera
          * @param name Define the name of the camera in the scene
          * @param position Define the start position of the camera in the scene
          * @param scene Define the scene the camera belongs to
@@ -19560,7 +19642,7 @@ declare module BABYLON {
              * Call this function to switch to webVR mode
              * Will do nothing if webVR is not supported or if there is no webVR device
              * @param options the webvr options provided to the camera. mainly used for multiview
-             * @see http://doc.babylonjs.com/how_to/webvr_camera
+             * @see https://doc.babylonjs.com/how_to/webvr_camera
              */
             enableVR(options: WebVROptions): void;
             /** @hidden */
@@ -19684,7 +19766,7 @@ declare module BABYLON {
     /**
      * This represents a WebVR camera.
      * The WebVR camera is Babylon's simple interface to interaction with Windows Mixed Reality, HTC Vive and Oculus Rift.
-     * @example http://doc.babylonjs.com/how_to/webvr_camera
+     * @example https://doc.babylonjs.com/how_to/webvr_camera
      */
     export class WebVRFreeCamera extends FreeCamera implements PoseControlled {
         private webVROptions;
@@ -19969,6 +20051,13 @@ declare module BABYLON {
          */
         static PrepareDefinesForMultiview(scene: Scene, defines: any): void;
         /**
+         * Prepares the defines related to the prepass
+         * @param scene The scene we are intending to draw
+         * @param defines The defines to update
+         * @param canRenderToMRT Indicates if this material renders to several textures in the prepass
+         */
+        static PrepareDefinesForPrePass(scene: Scene, defines: any, canRenderToMRT: boolean): void;
+        /**
          * Prepares the defines related to the light information passed in parameter
          * @param scene The scene we are intending to draw
          * @param mesh The mesh the effect is compiling for
@@ -20159,6 +20248,12 @@ declare module BABYLON {
          * @param type defines the type of the input (can be set to NodeMaterialBlockConnectionPointTypes.AutoDetect)
          */
         constructor(name: string, target?: NodeMaterialBlockTargets, type?: NodeMaterialBlockConnectionPointTypes);
+        /**
+        * Validates if a name is a reserve word.
+        * @param newName the new name to be given to the node.
+        * @returns false if the name is a reserve word, else true.
+        */
+        validateBlockName(newName: string): boolean;
         /**
          * Gets the output component
          */
@@ -21230,6 +21325,7 @@ declare module BABYLON {
         private _target;
         private _isFinalMerger;
         private _isInput;
+        private _name;
         protected _isUnique: boolean;
         /** Gets or sets a boolean indicating that only one input can be connected at a time */
         inputsAreExclusive: boolean;
@@ -21242,9 +21338,13 @@ declare module BABYLON {
         /** @hidden */
         _preparationId: number;
         /**
-         * Gets or sets the name of the block
+         * Gets the name of the block
          */
-        name: string;
+        get name(): string;
+        /**
+         * Sets the name of the block. Will check if the name is valid.
+         */
+        set name(newName: string);
         /**
          * Gets or sets the unique id of the node
          */
@@ -21426,6 +21526,12 @@ declare module BABYLON {
         isReady(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines, useInstances?: boolean): boolean;
         protected _linkConnectionTypes(inputIndex0: number, inputIndex1: number): void;
         private _processBuild;
+        /**
+        * Validates the new name for the block node.
+        * @param newName the new name to be given to the node.
+        * @returns false if the name is a reserve word, else true.
+        */
+        validateBlockName(newName: string): boolean;
         /**
          * Compile the current node and generate the shader code
          * @param state defines the current compilation state (uniforms, samplers, current string)
@@ -22352,9 +22458,9 @@ declare module BABYLON {
          *
          * | Value | Type                                | Description |
          * | ----- | ----------------------------------- | ----------- |
-         * | 1     | SCALEMODE_FLOOR                     | [engine.scalemode_floor](http://doc.babylonjs.com/api/classes/babylon.engine#scalemode_floor) |
-         * | 2     | SCALEMODE_NEAREST                   | [engine.scalemode_nearest](http://doc.babylonjs.com/api/classes/babylon.engine#scalemode_nearest) |
-         * | 3     | SCALEMODE_CEILING                   | [engine.scalemode_ceiling](http://doc.babylonjs.com/api/classes/babylon.engine#scalemode_ceiling) |
+         * | 1     | SCALEMODE_FLOOR                     | [engine.scalemode_floor](https://doc.babylonjs.com/api/classes/babylon.engine#scalemode_floor) |
+         * | 2     | SCALEMODE_NEAREST                   | [engine.scalemode_nearest](https://doc.babylonjs.com/api/classes/babylon.engine#scalemode_nearest) |
+         * | 3     | SCALEMODE_CEILING                   | [engine.scalemode_ceiling](https://doc.babylonjs.com/api/classes/babylon.engine#scalemode_ceiling) |
          *
          */
         scaleMode: number;
@@ -22373,7 +22479,7 @@ declare module BABYLON {
         */
         adaptScaleToCurrentViewport: boolean;
         private _camera;
-        private _scene;
+        protected _scene: Scene;
         private _engine;
         private _options;
         private _reusable;
@@ -22455,6 +22561,11 @@ declare module BABYLON {
         */
         get inputTexture(): InternalTexture;
         set inputTexture(value: InternalTexture);
+        /**
+        * Since inputTexture should always be defined, if we previously manually set `inputTexture`,
+        * the only way to unset it is to use this function to restore its internal state
+        */
+        restoreDefaultInputTexture(): void;
         /**
         * Gets the camera which post process is applied to.
         * @returns The camera the post process is applied to.
@@ -22786,7 +22897,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * This represents a texture in babylon. It can be easily loaded from a network, base64 or html input.
-     * @see http://doc.babylonjs.com/babylon101/materials#texture
+     * @see https://doc.babylonjs.com/babylon101/materials#texture
      */
     export class Texture extends BaseTexture {
         /**
@@ -22865,37 +22976,37 @@ declare module BABYLON {
         url: Nullable<string>;
         /**
          * Define an offset on the texture to offset the u coordinates of the UVs
-         * @see http://doc.babylonjs.com/how_to/more_materials#offsetting
+         * @see https://doc.babylonjs.com/how_to/more_materials#offsetting
          */
         uOffset: number;
         /**
          * Define an offset on the texture to offset the v coordinates of the UVs
-         * @see http://doc.babylonjs.com/how_to/more_materials#offsetting
+         * @see https://doc.babylonjs.com/how_to/more_materials#offsetting
          */
         vOffset: number;
         /**
          * Define an offset on the texture to scale the u coordinates of the UVs
-         * @see http://doc.babylonjs.com/how_to/more_materials#tiling
+         * @see https://doc.babylonjs.com/how_to/more_materials#tiling
          */
         uScale: number;
         /**
          * Define an offset on the texture to scale the v coordinates of the UVs
-         * @see http://doc.babylonjs.com/how_to/more_materials#tiling
+         * @see https://doc.babylonjs.com/how_to/more_materials#tiling
          */
         vScale: number;
         /**
          * Define an offset on the texture to rotate around the u coordinates of the UVs
-         * @see http://doc.babylonjs.com/how_to/more_materials
+         * @see https://doc.babylonjs.com/how_to/more_materials
          */
         uAng: number;
         /**
          * Define an offset on the texture to rotate around the v coordinates of the UVs
-         * @see http://doc.babylonjs.com/how_to/more_materials
+         * @see https://doc.babylonjs.com/how_to/more_materials
          */
         vAng: number;
         /**
          * Define an offset on the texture to rotate around the w coordinates of the UVs (in case of 3d texture)
-         * @see http://doc.babylonjs.com/how_to/more_materials
+         * @see https://doc.babylonjs.com/how_to/more_materials
          */
         wAng: number;
         /**
@@ -22968,7 +23079,7 @@ declare module BABYLON {
         /**
          * Instantiates a new texture.
          * This represents a texture in babylon. It can be easily loaded from a network, base64 or html input.
-         * @see http://doc.babylonjs.com/babylon101/materials#texture
+         * @see https://doc.babylonjs.com/babylon101/materials#texture
          * @param url defines the url of the picture to load as a texture
          * @param sceneOrEngine defines the scene or engine the texture will belong to
          * @param noMipmap defines if the texture will require mip maps or not
@@ -23101,8 +23212,9 @@ declare module BABYLON {
          * @param forceFullscreenViewport force gl.viewport to be full screen eg. 0,0,textureWidth,textureHeight
          * @param faceIndex defines the face to render to if a cubemap is defined as the target
          * @param lodLevel defines which lod of the texture to render to
+         * @param doNotBindFrambuffer If set to true, assumes that the framebuffer has been bound previously
          */
-        directRender(postProcesses: PostProcess[], targetTexture?: Nullable<InternalTexture>, forceFullscreenViewport?: boolean, faceIndex?: number, lodLevel?: number): void;
+        directRender(postProcesses: PostProcess[], targetTexture?: Nullable<InternalTexture>, forceFullscreenViewport?: boolean, faceIndex?: number, lodLevel?: number, doNotBindFrambuffer?: boolean): void;
         /**
          * Finalize the result of the output of the postprocesses.
          * @param doNotPresent If true the result will not be displayed to the screen.
@@ -23558,6 +23670,605 @@ declare module BABYLON {
     }
 }
 declare module BABYLON {
+        interface ThinEngine {
+            /**
+             * Unbind a list of render target textures from the webGL context
+             * This is used only when drawBuffer extension or webGL2 are active
+             * @param textures defines the render target textures to unbind
+             * @param disableGenerateMipMaps defines a boolean indicating that mipmaps must not be generated
+             * @param onBeforeUnbind defines a function which will be called before the effective unbind
+             */
+            unBindMultiColorAttachmentFramebuffer(textures: InternalTexture[], disableGenerateMipMaps: boolean, onBeforeUnbind?: () => void): void;
+            /**
+             * Create a multi render target texture
+             * @see https://doc.babylonjs.com/features/webgl2#multiple-render-target
+             * @param size defines the size of the texture
+             * @param options defines the creation options
+             * @returns the cube texture as an InternalTexture
+             */
+            createMultipleRenderTarget(size: any, options: IMultiRenderTargetOptions): InternalTexture[];
+            /**
+             * Update the sample count for a given multiple render target texture
+             * @see https://doc.babylonjs.com/features/webgl2#multisample-render-targets
+             * @param textures defines the textures to update
+             * @param samples defines the sample count to set
+             * @returns the effective sample count (could be 0 if multisample render targets are not supported)
+             */
+            updateMultipleRenderTargetTextureSampleCount(textures: Nullable<InternalTexture[]>, samples: number): number;
+            /**
+             * Select a subsets of attachments to draw to.
+             * @param attachments gl attachments
+             */
+            bindAttachments(attachments: number[]): void;
+        }
+}
+declare module BABYLON {
+    /**
+     * Creation options of the multi render target texture.
+     */
+    export interface IMultiRenderTargetOptions {
+        /**
+         * Define if the texture needs to create mip maps after render.
+         */
+        generateMipMaps?: boolean;
+        /**
+         * Define the types of all the draw buffers we want to create
+         */
+        types?: number[];
+        /**
+         * Define the sampling modes of all the draw buffers we want to create
+         */
+        samplingModes?: number[];
+        /**
+         * Define if a depth buffer is required
+         */
+        generateDepthBuffer?: boolean;
+        /**
+         * Define if a stencil buffer is required
+         */
+        generateStencilBuffer?: boolean;
+        /**
+         * Define if a depth texture is required instead of a depth buffer
+         */
+        generateDepthTexture?: boolean;
+        /**
+         * Define the number of desired draw buffers
+         */
+        textureCount?: number;
+        /**
+         * Define if aspect ratio should be adapted to the texture or stay the scene one
+         */
+        doNotChangeAspectRatio?: boolean;
+        /**
+         * Define the default type of the buffers we are creating
+         */
+        defaultType?: number;
+    }
+    /**
+     * A multi render target, like a render target provides the ability to render to a texture.
+     * Unlike the render target, it can render to several draw buffers in one draw.
+     * This is specially interesting in deferred rendering or for any effects requiring more than
+     * just one color from a single pass.
+     */
+    export class MultiRenderTarget extends RenderTargetTexture {
+        private _internalTextures;
+        private _textures;
+        private _multiRenderTargetOptions;
+        private _count;
+        /**
+         * Get if draw buffers are currently supported by the used hardware and browser.
+         */
+        get isSupported(): boolean;
+        /**
+         * Get the list of textures generated by the multi render target.
+         */
+        get textures(): Texture[];
+        /**
+         * Gets the number of textures in this MRT. This number can be different from `_textures.length` in case a depth texture is generated.
+         */
+        get count(): number;
+        /**
+         * Get the depth texture generated by the multi render target if options.generateDepthTexture has been set
+         */
+        get depthTexture(): Texture;
+        /**
+         * Set the wrapping mode on U of all the textures we are rendering to.
+         * Can be any of the Texture. (CLAMP_ADDRESSMODE, MIRROR_ADDRESSMODE or WRAP_ADDRESSMODE)
+         */
+        set wrapU(wrap: number);
+        /**
+         * Set the wrapping mode on V of all the textures we are rendering to.
+         * Can be any of the Texture. (CLAMP_ADDRESSMODE, MIRROR_ADDRESSMODE or WRAP_ADDRESSMODE)
+         */
+        set wrapV(wrap: number);
+        /**
+         * Instantiate a new multi render target texture.
+         * A multi render target, like a render target provides the ability to render to a texture.
+         * Unlike the render target, it can render to several draw buffers in one draw.
+         * This is specially interesting in deferred rendering or for any effects requiring more than
+         * just one color from a single pass.
+         * @param name Define the name of the texture
+         * @param size Define the size of the buffers to render to
+         * @param count Define the number of target we are rendering into
+         * @param scene Define the scene the texture belongs to
+         * @param options Define the options used to create the multi render target
+         */
+        constructor(name: string, size: any, count: number, scene: Scene, options?: IMultiRenderTargetOptions);
+        /** @hidden */
+        _rebuild(): void;
+        private _createInternalTextures;
+        private _createTextures;
+        /**
+         * Define the number of samples used if MSAA is enabled.
+         */
+        get samples(): number;
+        set samples(value: number);
+        /**
+         * Resize all the textures in the multi render target.
+         * Be carrefull as it will recreate all the data in the new texture.
+         * @param size Define the new size
+         */
+        resize(size: any): void;
+        protected unbindFrameBuffer(engine: Engine, faceIndex: number): void;
+        /**
+         * Dispose the render targets and their associated resources
+         */
+        dispose(): void;
+        /**
+         * Release all the underlying texture used as draw buffers.
+         */
+        releaseInternalTextures(): void;
+    }
+}
+declare module BABYLON {
+    /** @hidden */
+    export var imageProcessingPixelShader: {
+        name: string;
+        shader: string;
+    };
+}
+declare module BABYLON {
+    /**
+     * ImageProcessingPostProcess
+     * @see https://doc.babylonjs.com/how_to/how_to_use_postprocesses#imageprocessing
+     */
+    export class ImageProcessingPostProcess extends PostProcess {
+        /**
+         * Default configuration related to image processing available in the PBR Material.
+         */
+        protected _imageProcessingConfiguration: ImageProcessingConfiguration;
+        /**
+         * Gets the image processing configuration used either in this material.
+         */
+        get imageProcessingConfiguration(): ImageProcessingConfiguration;
+        /**
+         * Sets the Default image processing configuration used either in the this material.
+         *
+         * If sets to null, the scene one is in use.
+         */
+        set imageProcessingConfiguration(value: ImageProcessingConfiguration);
+        /**
+         * Keep track of the image processing observer to allow dispose and replace.
+         */
+        private _imageProcessingObserver;
+        /**
+         * Attaches a new image processing configuration to the PBR Material.
+         * @param configuration
+         */
+        protected _attachImageProcessingConfiguration(configuration: Nullable<ImageProcessingConfiguration>, doNotBuild?: boolean): void;
+        /**
+         * If the post process is supported.
+         */
+        get isSupported(): boolean;
+        /**
+         * Gets Color curves setup used in the effect if colorCurvesEnabled is set to true .
+         */
+        get colorCurves(): Nullable<ColorCurves>;
+        /**
+         * Sets Color curves setup used in the effect if colorCurvesEnabled is set to true .
+         */
+        set colorCurves(value: Nullable<ColorCurves>);
+        /**
+         * Gets wether the color curves effect is enabled.
+         */
+        get colorCurvesEnabled(): boolean;
+        /**
+         * Sets wether the color curves effect is enabled.
+         */
+        set colorCurvesEnabled(value: boolean);
+        /**
+         * Gets Color grading LUT texture used in the effect if colorGradingEnabled is set to true.
+         */
+        get colorGradingTexture(): Nullable<BaseTexture>;
+        /**
+         * Sets Color grading LUT texture used in the effect if colorGradingEnabled is set to true.
+         */
+        set colorGradingTexture(value: Nullable<BaseTexture>);
+        /**
+         * Gets wether the color grading effect is enabled.
+         */
+        get colorGradingEnabled(): boolean;
+        /**
+         * Gets wether the color grading effect is enabled.
+         */
+        set colorGradingEnabled(value: boolean);
+        /**
+         * Gets exposure used in the effect.
+         */
+        get exposure(): number;
+        /**
+         * Sets exposure used in the effect.
+         */
+        set exposure(value: number);
+        /**
+         * Gets wether tonemapping is enabled or not.
+         */
+        get toneMappingEnabled(): boolean;
+        /**
+         * Sets wether tonemapping is enabled or not
+         */
+        set toneMappingEnabled(value: boolean);
+        /**
+         * Gets the type of tone mapping effect.
+         */
+        get toneMappingType(): number;
+        /**
+         * Sets the type of tone mapping effect.
+         */
+        set toneMappingType(value: number);
+        /**
+         * Gets contrast used in the effect.
+         */
+        get contrast(): number;
+        /**
+         * Sets contrast used in the effect.
+         */
+        set contrast(value: number);
+        /**
+         * Gets Vignette stretch size.
+         */
+        get vignetteStretch(): number;
+        /**
+         * Sets Vignette stretch size.
+         */
+        set vignetteStretch(value: number);
+        /**
+         * Gets Vignette centre X Offset.
+         */
+        get vignetteCentreX(): number;
+        /**
+         * Sets Vignette centre X Offset.
+         */
+        set vignetteCentreX(value: number);
+        /**
+         * Gets Vignette centre Y Offset.
+         */
+        get vignetteCentreY(): number;
+        /**
+         * Sets Vignette centre Y Offset.
+         */
+        set vignetteCentreY(value: number);
+        /**
+         * Gets Vignette weight or intensity of the vignette effect.
+         */
+        get vignetteWeight(): number;
+        /**
+         * Sets Vignette weight or intensity of the vignette effect.
+         */
+        set vignetteWeight(value: number);
+        /**
+         * Gets Color of the vignette applied on the screen through the chosen blend mode (vignetteBlendMode)
+         * if vignetteEnabled is set to true.
+         */
+        get vignetteColor(): Color4;
+        /**
+         * Sets Color of the vignette applied on the screen through the chosen blend mode (vignetteBlendMode)
+         * if vignetteEnabled is set to true.
+         */
+        set vignetteColor(value: Color4);
+        /**
+         * Gets Camera field of view used by the Vignette effect.
+         */
+        get vignetteCameraFov(): number;
+        /**
+         * Sets Camera field of view used by the Vignette effect.
+         */
+        set vignetteCameraFov(value: number);
+        /**
+         * Gets the vignette blend mode allowing different kind of effect.
+         */
+        get vignetteBlendMode(): number;
+        /**
+         * Sets the vignette blend mode allowing different kind of effect.
+         */
+        set vignetteBlendMode(value: number);
+        /**
+         * Gets wether the vignette effect is enabled.
+         */
+        get vignetteEnabled(): boolean;
+        /**
+         * Sets wether the vignette effect is enabled.
+         */
+        set vignetteEnabled(value: boolean);
+        private _fromLinearSpace;
+        /**
+         * Gets wether the input of the processing is in Gamma or Linear Space.
+         */
+        get fromLinearSpace(): boolean;
+        /**
+         * Sets wether the input of the processing is in Gamma or Linear Space.
+         */
+        set fromLinearSpace(value: boolean);
+        /**
+         * Defines cache preventing GC.
+         */
+        private _defines;
+        constructor(name: string, options: number | PostProcessOptions, camera?: Nullable<Camera>, samplingMode?: number, engine?: Engine, reusable?: boolean, textureType?: number, imageProcessingConfiguration?: ImageProcessingConfiguration);
+        /**
+         *  "ImageProcessingPostProcess"
+         * @returns "ImageProcessingPostProcess"
+         */
+        getClassName(): string;
+        /**
+         * @hidden
+         */
+        _updateParameters(): void;
+        dispose(camera?: Camera): void;
+    }
+}
+declare module BABYLON {
+    /** @hidden */
+    export var fibonacci: {
+        name: string;
+        shader: string;
+    };
+}
+declare module BABYLON {
+    /** @hidden */
+    export var subSurfaceScatteringFunctions: {
+        name: string;
+        shader: string;
+    };
+}
+declare module BABYLON {
+    /** @hidden */
+    export var diffusionProfile: {
+        name: string;
+        shader: string;
+    };
+}
+declare module BABYLON {
+    /** @hidden */
+    export var subSurfaceScatteringPixelShader: {
+        name: string;
+        shader: string;
+    };
+}
+declare module BABYLON {
+    /**
+     * Sub surface scattering post process
+     */
+    export class SubSurfaceScatteringPostProcess extends PostProcess {
+        /** @hidden */
+        texelWidth: number;
+        /** @hidden */
+        texelHeight: number;
+        constructor(name: string, scene: Scene, options: number | PostProcessOptions, camera?: Nullable<Camera>, samplingMode?: number, engine?: Engine, reusable?: boolean, textureType?: number);
+    }
+}
+declare module BABYLON {
+    /**
+     * Interface for defining prepass effects in the prepass post-process pipeline
+     */
+    export interface PrePassEffectConfiguration {
+        /**
+         * Post process to attach for this effect
+         */
+        postProcess: PostProcess;
+        /**
+         * Is the effect enabled
+         */
+        enabled: boolean;
+        /**
+         * Disposes the effect configuration
+         */
+        dispose(): void;
+        /**
+         * Disposes the effect configuration
+         */
+        createPostProcess: () => PostProcess;
+    }
+}
+declare module BABYLON {
+    /**
+     * Contains all parameters needed for the prepass to perform
+     * screen space subsurface scattering
+     */
+    export class SubSurfaceConfiguration implements PrePassEffectConfiguration {
+        private _ssDiffusionS;
+        private _ssFilterRadii;
+        private _ssDiffusionD;
+        /**
+         * Post process to attach for screen space subsurface scattering
+         */
+        postProcess: SubSurfaceScatteringPostProcess;
+        /**
+         * Diffusion profile color for subsurface scattering
+         */
+        get ssDiffusionS(): number[];
+        /**
+         * Diffusion profile max color channel value for subsurface scattering
+         */
+        get ssDiffusionD(): number[];
+        /**
+         * Diffusion profile filter radius for subsurface scattering
+         */
+        get ssFilterRadii(): number[];
+        /**
+         * Is subsurface enabled
+         */
+        enabled: boolean;
+        /**
+         * Diffusion profile colors for subsurface scattering
+         * You can add one diffusion color using `addDiffusionProfile` on `scene.prePassRenderer`
+         * See ...
+         * Note that you can only store up to 5 of them
+         */
+        ssDiffusionProfileColors: Color3[];
+        /**
+         * Defines the ratio real world => scene units.
+         * Used for subsurface scattering
+         */
+        metersPerUnit: number;
+        private _scene;
+        /**
+         * Builds a subsurface configuration object
+         * @param scene The scene
+         */
+        constructor(scene: Scene);
+        /**
+         * Adds a new diffusion profile.
+         * Useful for more realistic subsurface scattering on diverse materials.
+         * @param color The color of the diffusion profile. Should be the average color of the material.
+         * @return The index of the diffusion profile for the material subsurface configuration
+         */
+        addDiffusionProfile(color: Color3): number;
+        /**
+         * Creates the sss post process
+         * @return The created post process
+         */
+        createPostProcess(): SubSurfaceScatteringPostProcess;
+        /**
+         * Deletes all diffusion profiles.
+         * Note that in order to render subsurface scattering, you should have at least 1 diffusion profile.
+         */
+        clearAllDiffusionProfiles(): void;
+        /**
+         * Disposes this object
+         */
+        dispose(): void;
+        /**
+         * @hidden
+         * https://zero-radiance.github.io/post/sampling-diffusion/
+         *
+         * Importance sample the normalized diffuse reflectance profile for the computed value of 's'.
+         * ------------------------------------------------------------------------------------
+         * R[r, phi, s]   = s * (Exp[-r * s] + Exp[-r * s / 3]) / (8 * Pi * r)
+         * PDF[r, phi, s] = r * R[r, phi, s]
+         * CDF[r, s]      = 1 - 1/4 * Exp[-r * s] - 3/4 * Exp[-r * s / 3]
+         * ------------------------------------------------------------------------------------
+         * We importance sample the color channel with the widest scattering distance.
+         */
+        getDiffusionProfileParameters(color: Color3): number;
+        /**
+         * Performs sampling of a Normalized Burley diffusion profile in polar coordinates.
+         * 'u' is the random number (the value of the CDF): [0, 1).
+         * rcp(s) = 1 / ShapeParam = ScatteringDistance.
+         * Returns the sampled radial distance, s.t. (u = 0 -> r = 0) and (u = 1 -> r = Inf).
+         */
+        private _sampleBurleyDiffusionProfile;
+    }
+}
+declare module BABYLON {
+    /**
+     * Renders a pre pass of the scene
+     * This means every mesh in the scene will be rendered to a render target texture
+     * And then this texture will be composited to the rendering canvas with post processes
+     * It is necessary for effects like subsurface scattering or deferred shading
+     */
+    export class PrePassRenderer {
+        /** @hidden */
+        static _SceneComponentInitialization: (scene: Scene) => void;
+        private _scene;
+        private _engine;
+        private _isDirty;
+        /**
+         * Number of textures in the multi render target texture where the scene is directly rendered
+         */
+        readonly mrtCount: number;
+        /**
+         * The render target where the scene is directly rendered
+         */
+        prePassRT: MultiRenderTarget;
+        private _mrtTypes;
+        private _multiRenderAttachments;
+        private _defaultAttachments;
+        private _clearAttachments;
+        private _postProcesses;
+        private readonly _clearColor;
+        /**
+         * Image processing post process for composition
+         */
+        imageProcessingPostProcess: ImageProcessingPostProcess;
+        /**
+         * Configuration for sub surface scattering post process
+         */
+        subSurfaceConfiguration: SubSurfaceConfiguration;
+        /**
+         * Should materials render their geometry on the MRT
+         */
+        materialsShouldRenderGeometry: boolean;
+        /**
+         * Should materials render the irradiance information on the MRT
+         */
+        materialsShouldRenderIrradiance: boolean;
+        private _enabled;
+        /**
+         * Indicates if the prepass is enabled
+         */
+        get enabled(): boolean;
+        /**
+         * How many samples are used for MSAA of the scene render target
+         */
+        get samples(): number;
+        set samples(n: number);
+        /**
+         * Instanciates a prepass renderer
+         * @param scene The scene
+         */
+        constructor(scene: Scene);
+        private _initializeAttachments;
+        private _createCompositionEffect;
+        /**
+         * Indicates if rendering a prepass is supported
+         */
+        get isSupported(): boolean;
+        /**
+         * Sets the proper output textures to draw in the engine.
+         * @param effect The effect that is drawn. It can be or not be compatible with drawing to several output textures.
+         */
+        bindAttachmentsForEffect(effect: Effect): void;
+        /**
+         * @hidden
+         */
+        _beforeCameraDraw(): void;
+        /**
+         * @hidden
+         */
+        _afterCameraDraw(): void;
+        private _checkRTSize;
+        private _bindFrameBuffer;
+        /**
+         * Clears the scene render target (in the sense of settings pixels to the scene clear color value)
+         */
+        clear(): void;
+        private _setState;
+        private _enable;
+        private _disable;
+        private _resetPostProcessChain;
+        private _bindPostProcessChain;
+        /**
+         * Marks the prepass renderer as dirty, triggering a check if the prepass is necessary for the next rendering.
+         */
+        markAsDirty(): void;
+        private _update;
+        /**
+         * Disposes the prepass renderer.
+         */
+        dispose(): void;
+    }
+}
+declare module BABYLON {
     /**
      * Options for compiling materials.
      */
@@ -23725,6 +24436,10 @@ declare module BABYLON {
          * The state of the material
          */
         state: string;
+        /**
+         * If the material can be rendered to several textures with MRT extension
+         */
+        get canRenderToMRT(): boolean;
         /**
          * The alpha value of the material
          */
@@ -24183,8 +24898,12 @@ declare module BABYLON {
          */
         protected _markAllSubMeshesAsDirty(func: (defines: MaterialDefines) => void): void;
         /**
-     * Indicates that we need to re-calculated for all submeshes
-     */
+         * Indicates that the scene should check if the rendering now needs a prepass
+         */
+        protected _markScenePrePassDirty(): void;
+        /**
+         * Indicates that we need to re-calculated for all submeshes
+         */
         protected _markAllSubMeshesAsAllDirty(): void;
         /**
          * Indicates that image processing needs to be re-calculated for all submeshes
@@ -24219,6 +24938,12 @@ declare module BABYLON {
          */
         protected _markAllSubMeshesAsTexturesAndMiscDirty(): void;
         /**
+         * Sets the required values to the prepass renderer.
+         * @param prePassRenderer defines the prepass renderer to setup.
+         * @returns true if the pre pass is needed.
+         */
+        setPrePassRenderer(prePassRenderer: PrePassRenderer): boolean;
+        /**
          * Disposes the material
          * @param forceDisposeEffect specifies if effects should be forcefully disposed
          * @param forceDisposeTextures specifies if textures should be forcefully disposed
@@ -24246,7 +24971,7 @@ declare module BABYLON {
     /**
      * A multi-material is used to apply different materials to different parts of the same object without the need of
      * separate meshes. This can be use to improve performances.
-     * @see http://doc.babylonjs.com/how_to/multi_materials
+     * @see https://doc.babylonjs.com/how_to/multi_materials
      */
     export class MultiMaterial extends Material {
         private _subMaterials;
@@ -24265,7 +24990,7 @@ declare module BABYLON {
          * Instantiates a new Multi Material
          * A multi-material is used to apply different materials to different parts of the same object without the need of
          * separate meshes. This can be use to improve performances.
-         * @see http://doc.babylonjs.com/how_to/multi_materials
+         * @see https://doc.babylonjs.com/how_to/multi_materials
          * @param name Define the name in the scene
          * @param scene Define the scene the material belongs to
          */
@@ -24652,6 +25377,11 @@ declare module BABYLON {
         static CreateGeometryForMesh(mesh: Mesh): Geometry;
         /** Get the list of meshes using this geometry */
         get meshes(): Mesh[];
+        /**
+         * If set to true (false by defaut), the bounding info applied to the meshes sharing this geometry will be the bounding info defined at the class level
+         * and won't be computed based on the vertex positions (which is what we get when useBoundingInfoFromGeometry = false)
+         */
+        useBoundingInfoFromGeometry: boolean;
         /**
          * Creates a new geometry
          * @param id defines the unique ID
@@ -25568,7 +26298,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Defines a target to use with MorphTargetManager
-     * @see http://doc.babylonjs.com/how_to/how_to_use_morphtargets
+     * @see https://doc.babylonjs.com/how_to/how_to_use_morphtargets
      */
     export class MorphTarget implements IAnimatable {
         /** defines the name of the target */
@@ -25708,7 +26438,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * This class is used to deform meshes using morphing between different targets
-     * @see http://doc.babylonjs.com/how_to/how_to_use_morphtargets
+     * @see https://doc.babylonjs.com/how_to/how_to_use_morphtargets
      */
     export class MorphTargetManager {
         private _targets;
@@ -25821,7 +26551,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to represent a specific level of detail of a mesh
-     * @see http://doc.babylonjs.com/how_to/how_to_use_lod
+     * @see https://doc.babylonjs.com/how_to/how_to_use_lod
      */
     export class MeshLODLevel {
         /** Defines the distance where this level should start being displayed */
@@ -26366,7 +27096,7 @@ declare module BABYLON {
     }
     /**
      * Interface used to define a physics engine
-     * @see http://doc.babylonjs.com/how_to/using_the_physics_engine
+     * @see https://doc.babylonjs.com/how_to/using_the_physics_engine
      */
     export interface IPhysicsEngine {
         /**
@@ -27265,14 +27995,14 @@ declare module BABYLON {
         get hasThinInstances(): boolean;
         /**
          * Gets the delay loading state of the mesh (when delay loading is turned on)
-         * @see http://doc.babylonjs.com/how_to/using_the_incremental_loading_system
+         * @see https://doc.babylonjs.com/how_to/using_the_incremental_loading_system
          */
         delayLoadState: number;
         /**
          * Gets the list of instances created from this mesh
          * it is not supposed to be modified manually.
          * Note also that the order of the InstancedMesh wihin the array is not significant and might change.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_instances
+         * @see https://doc.babylonjs.com/how_to/how_to_use_instances
          */
         instances: InstancedMesh[];
         /**
@@ -27283,12 +28013,12 @@ declare module BABYLON {
         _binaryInfo: any;
         /**
          * User defined function used to change how LOD level selection is done
-         * @see http://doc.babylonjs.com/how_to/how_to_use_lod
+         * @see https://doc.babylonjs.com/how_to/how_to_use_lod
          */
         onLODLevelSelection: (distance: number, mesh: Mesh, selectedLevel: Nullable<Mesh>) => void;
         /**
          * Gets or sets the morph target manager
-         * @see http://doc.babylonjs.com/how_to/how_to_use_morphtargets
+         * @see https://doc.babylonjs.com/how_to/how_to_use_morphtargets
          */
         get morphTargetManager(): Nullable<MorphTargetManager>;
         set morphTargetManager(value: Nullable<MorphTargetManager>);
@@ -27647,7 +28377,7 @@ declare module BABYLON {
         updateVerticesData(kind: string, data: FloatArray, updateExtends?: boolean, makeItUnique?: boolean): AbstractMesh;
         /**
          * This method updates the vertex positions of an updatable mesh according to the `positionFunction` returned values.
-         * @see http://doc.babylonjs.com/how_to/how_to_dynamically_morph_a_mesh#other-shapes-updatemeshpositions
+         * @see https://doc.babylonjs.com/how_to/how_to_dynamically_morph_a_mesh#other-shapes-updatemeshpositions
          * @param positionFunction is a simple JS function what is passed the mesh `positions` array. It doesn't need to return anything
          * @param computeNormals is a boolean (default true) to enable/disable the mesh normal recomputation after the vertex position update
          * @returns the current mesh
@@ -27779,7 +28509,7 @@ declare module BABYLON {
          * The mesh normals are modified using the same transformation.
          * Note that, under the hood, this method sets a new VertexBuffer each call.
          * @param transform defines the transform matrix to use
-         * @see http://doc.babylonjs.com/resources/baking_transformations
+         * @see https://doc.babylonjs.com/resources/baking_transformations
          * @returns the current mesh
          */
         bakeTransformIntoVertices(transform: Matrix): Mesh;
@@ -27788,7 +28518,7 @@ declare module BABYLON {
          * The mesh World Matrix is then reset.
          * This method returns nothing but really modifies the mesh even if it's originally not set as updatable.
          * Note that, under the hood, this method sets a new VertexBuffer each call.
-         * @see http://doc.babylonjs.com/resources/baking_transformations
+         * @see https://doc.babylonjs.com/resources/baking_transformations
          * @param bakeIndependenlyOfChildren indicates whether to preserve all child nodes' World Matrix during baking
          * @returns the current mesh
          */
@@ -27889,7 +28619,7 @@ declare module BABYLON {
         static _PhysicsImpostorParser(scene: Scene, physicObject: IPhysicsEnabledObject, jsonObject: any): PhysicsImpostor;
         /**
          * Creates a new InstancedMesh object from the mesh model.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_instances
+         * @see https://doc.babylonjs.com/how_to/how_to_use_instances
          * @param name defines the name of the new instance
          * @returns a new InstancedMesh
          */
@@ -27927,7 +28657,7 @@ declare module BABYLON {
         static Parse(parsedMesh: any, scene: Scene, rootUrl: string): Mesh;
         /**
          * Creates a ribbon mesh. Please consider using the same method from the MeshBuilder class instead
-         * @see http://doc.babylonjs.com/how_to/parametric_shapes
+         * @see https://doc.babylonjs.com/how_to/parametric_shapes
          * @param name defines the name of the mesh to create
          * @param pathArray is a required array of paths, what are each an array of successive Vector3. The pathArray parameter depicts the ribbon geometry.
          * @param closeArray creates a seam between the first and the last paths of the path array (default is false)
@@ -27935,8 +28665,8 @@ declare module BABYLON {
          * @param offset is taken in account only if the `pathArray` is containing a single path
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
-         * @param instance defines an instance of an existing Ribbon object to be updated with the passed `pathArray` parameter (http://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#ribbon)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param instance defines an instance of an existing Ribbon object to be updated with the passed `pathArray` parameter (https://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#ribbon)
          * @returns a new Mesh
          */
         static CreateRibbon(name: string, pathArray: Vector3[][], closeArray: boolean, closePath: boolean, offset: number, scene?: Scene, updatable?: boolean, sideOrientation?: number, instance?: Mesh): Mesh;
@@ -27947,7 +28677,7 @@ declare module BABYLON {
           * @param tessellation sets the number of polygon sides (positive integer, default 64). So a tessellation valued to 3 will build a triangle, to 4 a square, etc
           * @param scene defines the hosting scene
           * @param updatable defines if the mesh must be flagged as updatable
-          * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+          * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
           * @returns a new Mesh
           */
         static CreateDisc(name: string, radius: number, tessellation: number, scene?: Nullable<Scene>, updatable?: boolean, sideOrientation?: number): Mesh;
@@ -27957,7 +28687,7 @@ declare module BABYLON {
          * @param size sets the size (float) of each box side (default 1)
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
          * @returns a new Mesh
          */
         static CreateBox(name: string, size: number, scene?: Nullable<Scene>, updatable?: boolean, sideOrientation?: number): Mesh;
@@ -27968,7 +28698,7 @@ declare module BABYLON {
           * @param diameter sets the diameter size (float) of the sphere (default 1)
           * @param scene defines the hosting scene
           * @param updatable defines if the mesh must be flagged as updatable
-          * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+          * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
           * @returns a new Mesh
           */
         static CreateSphere(name: string, segments: number, diameter: number, scene?: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
@@ -27991,7 +28721,7 @@ declare module BABYLON {
          * @param subdivisions sets the number of rings along the cylinder height (positive integer, default 1)
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
          * @returns a new Mesh
          */
         static CreateCylinder(name: string, height: number, diameterTop: number, diameterBottom: number, tessellation: number, subdivisions: any, scene?: Scene, updatable?: any, sideOrientation?: number): Mesh;
@@ -28003,7 +28733,7 @@ declare module BABYLON {
          * @param tessellation sets the number of torus sides (postive integer, default 16)
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
          * @returns a new Mesh
          */
         static CreateTorus(name: string, diameter: number, thickness: number, tessellation: number, scene?: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
@@ -28018,7 +28748,7 @@ declare module BABYLON {
          * @param q the number of windings on Y axis (positive integers, default 3)
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
          * @returns a new Mesh
          */
         static CreateTorusKnot(name: string, radius: number, tube: number, radialSegments: number, tubularSegments: number, p: number, q: number, scene?: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
@@ -28028,7 +28758,7 @@ declare module BABYLON {
          * @param points is an array successive Vector3
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param instance is an instance of an existing LineMesh object to be updated with the passed `points` parameter (http://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#lines-and-dashedlines).
+         * @param instance is an instance of an existing LineMesh object to be updated with the passed `points` parameter (https://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#lines-and-dashedlines).
          * @returns a new Mesh
          */
         static CreateLines(name: string, points: Vector3[], scene?: Nullable<Scene>, updatable?: boolean, instance?: Nullable<LinesMesh>): LinesMesh;
@@ -28041,7 +28771,7 @@ declare module BABYLON {
          * @param dashNb is the intended total number of dashes (positive integer, default 200)
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param instance is an instance of an existing LineMesh object to be updated with the passed `points` parameter (http://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#lines-and-dashedlines)
+         * @param instance is an instance of an existing LineMesh object to be updated with the passed `points` parameter (https://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#lines-and-dashedlines)
          * @returns a new Mesh
          */
         static CreateDashedLines(name: string, points: Vector3[], dashSize: number, gapSize: number, dashNb: number, scene?: Nullable<Scene>, updatable?: boolean, instance?: LinesMesh): LinesMesh;
@@ -28052,27 +28782,27 @@ declare module BABYLON {
          * You can set the mesh side orientation with the values : Mesh.FRONTSIDE (default), Mesh.BACKSIDE or Mesh.DOUBLESIDE
          * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created.
          * Remember you can only change the shape positions, not their number when updating a polygon.
-         * @see http://doc.babylonjs.com/how_to/parametric_shapes#non-regular-polygon
+         * @see https://doc.babylonjs.com/how_to/parametric_shapes#non-regular-polygon
          * @param name defines the name of the mesh to create
          * @param shape is a required array of successive Vector3 representing the corners of the polygon in th XoZ plane, that is y = 0 for all vectors
          * @param scene defines the hosting scene
          * @param holes is a required array of arrays of successive Vector3 used to defines holes in the polygon
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
          * @param earcutInjection can be used to inject your own earcut reference
          * @returns a new Mesh
          */
         static CreatePolygon(name: string, shape: Vector3[], scene: Scene, holes?: Vector3[][], updatable?: boolean, sideOrientation?: number, earcutInjection?: any): Mesh;
         /**
          * Creates an extruded polygon mesh, with depth in the Y direction. Please consider using the same method from the MeshBuilder class instead.
-         * @see http://doc.babylonjs.com/how_to/parametric_shapes#extruded-non-regular-polygon
+         * @see https://doc.babylonjs.com/how_to/parametric_shapes#extruded-non-regular-polygon
          * @param name defines the name of the mesh to create
          * @param shape is a required array of successive Vector3 representing the corners of the polygon in th XoZ plane, that is y = 0 for all vectors
          * @param depth defines the height of extrusion
          * @param scene defines the hosting scene
          * @param holes is a required array of arrays of successive Vector3 used to defines holes in the polygon
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
          * @param earcutInjection can be used to inject your own earcut reference
          * @returns a new Mesh
          */
@@ -28080,8 +28810,8 @@ declare module BABYLON {
         /**
          * Creates an extruded shape mesh.
          * The extrusion is a parametric shape. It has no predefined shape. Its final shape will depend on the input parameters. Please consider using the same method from the MeshBuilder class instead
-         * @see http://doc.babylonjs.com/how_to/parametric_shapes
-         * @see http://doc.babylonjs.com/how_to/parametric_shapes#extruded-shapes
+         * @see https://doc.babylonjs.com/how_to/parametric_shapes
+         * @see https://doc.babylonjs.com/how_to/parametric_shapes#extruded-shapes
          * @param name defines the name of the mesh to create
          * @param shape is a required array of successive Vector3. This array depicts the shape to be extruded in its local space : the shape must be designed in the xOy plane and will be extruded along the Z axis
          * @param path is a required array of successive Vector3. This is the axis curve the shape is extruded along
@@ -28090,8 +28820,8 @@ declare module BABYLON {
          * @param cap sets the way the extruded shape is capped. Possible values : Mesh.NO_CAP (default), Mesh.CAP_START, Mesh.CAP_END, Mesh.CAP_ALL
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
-         * @param instance is an instance of an existing ExtrudedShape object to be updated with the passed `shape`, `path`, `scale` or `rotation` parameters (http://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#extruded-shape)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param instance is an instance of an existing ExtrudedShape object to be updated with the passed `shape`, `path`, `scale` or `rotation` parameters (https://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#extruded-shape)
          * @returns a new Mesh
          */
         static ExtrudeShape(name: string, shape: Vector3[], path: Vector3[], scale: number, rotation: number, cap: number, scene?: Nullable<Scene>, updatable?: boolean, sideOrientation?: number, instance?: Mesh): Mesh;
@@ -28100,7 +28830,7 @@ declare module BABYLON {
          * The custom extrusion is a parametric shape.
          * It has no predefined shape. Its final shape will depend on the input parameters.
          * Please consider using the same method from the MeshBuilder class instead
-         * @see http://doc.babylonjs.com/how_to/parametric_shapes#extruded-shapes
+         * @see https://doc.babylonjs.com/how_to/parametric_shapes#extruded-shapes
          * @param name defines the name of the mesh to create
          * @param shape is a required array of successive Vector3. This array depicts the shape to be extruded in its local space : the shape must be designed in the xOy plane and will be extruded along the Z axis
          * @param path is a required array of successive Vector3. This is the axis curve the shape is extruded along
@@ -28111,8 +28841,8 @@ declare module BABYLON {
          * @param cap sets the way the extruded shape is capped. Possible values : Mesh.NO_CAP (default), Mesh.CAP_START, Mesh.CAP_END, Mesh.CAP_ALL
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
-         * @param instance is an instance of an existing ExtrudedShape object to be updated with the passed `shape`, `path`, `scale` or `rotation` parameters (http://doc.babylonjs.com/how_to/how_to_dynamically_morph_a_mesh#extruded-shape)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param instance is an instance of an existing ExtrudedShape object to be updated with the passed `shape`, `path`, `scale` or `rotation` parameters (https://doc.babylonjs.com/how_to/how_to_dynamically_morph_a_mesh#extruded-shape)
          * @returns a new Mesh
          */
         static ExtrudeShapeCustom(name: string, shape: Vector3[], path: Vector3[], scaleFunction: Function, rotationFunction: Function, ribbonCloseArray: boolean, ribbonClosePath: boolean, cap: number, scene: Scene, updatable?: boolean, sideOrientation?: number, instance?: Mesh): Mesh;
@@ -28126,7 +28856,7 @@ declare module BABYLON {
          * @param tessellation is the side number of the lathe.
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
          * @returns a new Mesh
          */
         static CreateLathe(name: string, shape: Vector3[], radius: number, tessellation: number, scene: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
@@ -28136,7 +28866,7 @@ declare module BABYLON {
          * @param size sets the size (float) of both sides of the plane at once (default 1)
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
          * @returns a new Mesh
          */
         static CreatePlane(name: string, size: number, scene: Scene, updatable?: boolean, sideOrientation?: number): Mesh;
@@ -28176,7 +28906,7 @@ declare module BABYLON {
         /**
          * Creates a ground mesh from a height map.
          * Please consider using the same method from the MeshBuilder class instead
-         * @see http://doc.babylonjs.com/babylon101/height_map
+         * @see https://doc.babylonjs.com/babylon101/height_map
          * @param name defines the name of the mesh to create
          * @param url sets the URL of the height map image resource
          * @param width set the ground width size
@@ -28196,7 +28926,7 @@ declare module BABYLON {
          * The tube is a parametric shape.
          * It has no predefined shape. Its final shape will depend on the input parameters.
          * Please consider using the same method from the MeshBuilder class instead
-         * @see http://doc.babylonjs.com/how_to/parametric_shapes
+         * @see https://doc.babylonjs.com/how_to/parametric_shapes
          * @param name defines the name of the mesh to create
          * @param path is a required array of successive Vector3. It is the curve used as the axis of the tube
          * @param radius sets the tube radius size
@@ -28205,8 +28935,8 @@ declare module BABYLON {
          * @param cap sets the way the extruded shape is capped. Possible values : Mesh.NO_CAP (default), Mesh.CAP_START, Mesh.CAP_END, Mesh.CAP_ALL
          * @param scene defines the hosting scene
          * @param updatable defines if the mesh must be flagged as updatable
-         * @param sideOrientation defines the mesh side orientation (http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
-         * @param instance is an instance of an existing Tube object to be updated with the passed `pathArray` parameter (http://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#tube)
+         * @param sideOrientation defines the mesh side orientation (https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation)
+         * @param instance is an instance of an existing Tube object to be updated with the passed `pathArray` parameter (https://doc.babylonjs.com/how_to/How_to_dynamically_morph_a_mesh#tube)
          * @returns a new Mesh
          */
         static CreateTube(name: string, path: Vector3[], radius: number, tessellation: number, radiusFunction: {
@@ -28224,7 +28954,7 @@ declare module BABYLON {
           * * To understand how to set `faceUV` or `faceColors`, please read this by considering the right number of faces of your polyhedron, instead of only 6 for the box : https://doc.babylonjs.com/how_to/createbox_per_face_textures_and_colors
           * * The parameter `flat` (boolean, default true). If set to false, it gives the polyhedron a single global face, so less vertices and shared normals. In this case, `faceColors` and `faceUV` are ignored
           * * You can also set the mesh side orientation with the values : Mesh.FRONTSIDE (default), Mesh.BACKSIDE or Mesh.DOUBLESIDE
-          * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation
+          * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation
           * * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created
           * @param name defines the name of the mesh to create
           * @param options defines the options used to create the mesh
@@ -28250,13 +28980,13 @@ declare module BABYLON {
          * * The parameter `subdivisions` sets the number of subdivisions (postive integer, default 4). The more subdivisions, the more faces on the icosphere whatever its size
          * * The parameter `flat` (boolean, default true) gives each side its own normals. Set it to false to get a smooth continuous light reflection on the surface
          * * You can also set the mesh side orientation with the values : Mesh.FRONTSIDE (default), Mesh.BACKSIDE or Mesh.DOUBLESIDE
-         * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : http://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation
+         * * If you create a double-sided mesh, you can choose what parts of the texture image to crop and stick respectively on the front and the back sides with the parameters `frontUVs` and `backUVs` (Vector4). Detail here : https://doc.babylonjs.com/babylon101/discover_basic_elements#side-orientation
          * * The mesh can be set to updatable with the boolean parameter `updatable` (default false) if its internal geometry is supposed to change once created
          * @param name defines the name of the mesh
          * @param options defines the options used to create the mesh
          * @param scene defines the hosting scene
          * @returns a new Mesh
-         * @see http://doc.babylonjs.com/how_to/polyhedra_shapes#icosphere
+         * @see https://doc.babylonjs.com/how_to/polyhedra_shapes#icosphere
          */
         static CreateIcoSphere(name: string, options: {
             radius?: number;
@@ -28332,7 +29062,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * This is the base class of all the camera used in the application.
-     * @see http://doc.babylonjs.com/features/cameras
+     * @see https://doc.babylonjs.com/features/cameras
      */
     export class Camera extends Node {
         /** @hidden */
@@ -28559,7 +29289,7 @@ declare module BABYLON {
         /**
          * Instantiates a new camera object.
          * This should not be used directly but through the inherited cameras: ArcRotate, Free...
-         * @see http://doc.babylonjs.com/features/cameras
+         * @see https://doc.babylonjs.com/features/cameras
          * @param name Defines the name of the camera in the scene
          * @param position Defines the position of the camera
          * @param scene Defines the scene the camera belongs too
@@ -28655,7 +29385,7 @@ declare module BABYLON {
         private _cascadePostProcessesToRigCams;
         /**
          * Attach a post process to the camera.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_postprocesses#attach-postprocess
+         * @see https://doc.babylonjs.com/how_to/how_to_use_postprocesses#attach-postprocess
          * @param postProcess The post process to attach to the camera
          * @param insertAt The position of the post process in case several of them are in use in the scene
          * @returns the position the post process has been inserted at
@@ -28663,7 +29393,7 @@ declare module BABYLON {
         attachPostProcess(postProcess: PostProcess, insertAt?: Nullable<number>): number;
         /**
          * Detach a post process to the camera.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_postprocesses#attach-postprocess
+         * @see https://doc.babylonjs.com/how_to/how_to_use_postprocesses#attach-postprocess
          * @param postProcess The post process to detach from the camera
          */
         detachPostProcess(postProcess: PostProcess): void;
@@ -28937,7 +29667,7 @@ declare module BABYLON {
     };
     /**
      * This represents all the required information to add a fresnel effect on a material:
-     * @see http://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
+     * @see https://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
      */
     export class FresnelParameters {
         private _isEnabled;
@@ -29117,6 +29847,13 @@ declare module BABYLON {
 declare module BABYLON {
     /** @hidden */
     export var defaultUboDeclaration: {
+        name: string;
+        shader: string;
+    };
+}
+declare module BABYLON {
+    /** @hidden */
+    export var prePassDeclaration: {
         name: string;
         shader: string;
     };
@@ -29496,6 +30233,8 @@ declare module BABYLON {
         PREMULTIPLYALPHA: boolean;
         ALPHATEST_AFTERALLALPHACOMPUTATIONS: boolean;
         ALPHABLEND: boolean;
+        PREPASS: boolean;
+        SCENE_MRT_COUNT: number;
         RGBDLIGHTMAP: boolean;
         RGBDREFLECTION: boolean;
         RGBDREFRACTION: boolean;
@@ -29530,7 +30269,7 @@ declare module BABYLON {
     /**
      * This is the default material used in Babylon. It is the best trade off between quality
      * and performances.
-     * @see http://doc.babylonjs.com/babylon101/materials
+     * @see https://doc.babylonjs.com/babylon101/materials
      */
     export class StandardMaterial extends PushMaterial {
         private _diffuseTexture;
@@ -29553,7 +30292,7 @@ declare module BABYLON {
         private _reflectionTexture;
         /**
          * Define the texture used to display the reflection.
-         * @see http://doc.babylonjs.com/how_to/reflect#how-to-obtain-reflections-and-refractions
+         * @see https://doc.babylonjs.com/how_to/reflect#how-to-obtain-reflections-and-refractions
          */
         reflectionTexture: Nullable<BaseTexture>;
         private _emissiveTexture;
@@ -29571,25 +30310,25 @@ declare module BABYLON {
         /**
          * Bump mapping is a technique to simulate bump and dents on a rendered surface.
          * These are made by creating a normal map from an image. The means to do this can be found on the web, a search for 'normal map generator' will bring up free and paid for methods of doing this.
-         * @see http://doc.babylonjs.com/how_to/more_materials#bump-map
+         * @see https://doc.babylonjs.com/how_to/more_materials#bump-map
          */
         bumpTexture: Nullable<BaseTexture>;
         private _lightmapTexture;
         /**
          * Complex lighting can be computationally expensive to compute at runtime.
          * To save on computation, lightmaps may be used to store calculated lighting in a texture which will be applied to a given mesh.
-         * @see http://doc.babylonjs.com/babylon101/lights#lightmaps
+         * @see https://doc.babylonjs.com/babylon101/lights#lightmaps
          */
         lightmapTexture: Nullable<BaseTexture>;
         private _refractionTexture;
         /**
          * Define the texture used to display the refraction.
-         * @see http://doc.babylonjs.com/how_to/reflect#how-to-obtain-reflections-and-refractions
+         * @see https://doc.babylonjs.com/how_to/reflect#how-to-obtain-reflections-and-refractions
          */
         refractionTexture: Nullable<BaseTexture>;
         /**
          * The color of the material lit by the environmental background lighting.
-         * @see http://doc.babylonjs.com/babylon101/materials#ambient-color-example
+         * @see https://doc.babylonjs.com/babylon101/materials#ambient-color-example
          */
         ambientColor: Color3;
         /**
@@ -29653,14 +30392,14 @@ declare module BABYLON {
         private _useParallax;
         /**
          * Is parallax enabled or not.
-         * @see http://doc.babylonjs.com/how_to/using_parallax_mapping
+         * @see https://doc.babylonjs.com/how_to/using_parallax_mapping
          */
         useParallax: boolean;
         private _useParallaxOcclusion;
         /**
          * Is parallax occlusion enabled or not.
          * If true, the outcome is way more realistic than traditional Parallax but you can expect a performance hit that worthes consideration.
-         * @see http://doc.babylonjs.com/how_to/using_parallax_mapping
+         * @see https://doc.babylonjs.com/how_to/using_parallax_mapping
          */
         useParallaxOcclusion: boolean;
         /**
@@ -29674,13 +30413,13 @@ declare module BABYLON {
         roughness: number;
         /**
          * In case of refraction, define the value of the index of refraction.
-         * @see http://doc.babylonjs.com/how_to/reflect#how-to-obtain-reflections-and-refractions
+         * @see https://doc.babylonjs.com/how_to/reflect#how-to-obtain-reflections-and-refractions
          */
         indexOfRefraction: number;
         /**
          * Invert the refraction texture alongside the y axis.
          * It can be useful with procedural textures or probe for instance.
-         * @see http://doc.babylonjs.com/how_to/reflect#how-to-obtain-reflections-and-refractions
+         * @see https://doc.babylonjs.com/how_to/reflect#how-to-obtain-reflections-and-refractions
          */
         invertRefractionY: boolean;
         /**
@@ -29695,37 +30434,37 @@ declare module BABYLON {
         private _diffuseFresnelParameters;
         /**
          * Define the diffuse fresnel parameters of the material.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
+         * @see https://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
          */
         diffuseFresnelParameters: FresnelParameters;
         private _opacityFresnelParameters;
         /**
          * Define the opacity fresnel parameters of the material.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
+         * @see https://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
          */
         opacityFresnelParameters: FresnelParameters;
         private _reflectionFresnelParameters;
         /**
          * Define the reflection fresnel parameters of the material.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
+         * @see https://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
          */
         reflectionFresnelParameters: FresnelParameters;
         private _refractionFresnelParameters;
         /**
          * Define the refraction fresnel parameters of the material.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
+         * @see https://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
          */
         refractionFresnelParameters: FresnelParameters;
         private _emissiveFresnelParameters;
         /**
          * Define the emissive fresnel parameters of the material.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
+         * @see https://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
          */
         emissiveFresnelParameters: FresnelParameters;
         private _useReflectionFresnelFromSpecular;
         /**
          * If true automatically deducts the fresnels values from the material specularity.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
+         * @see https://doc.babylonjs.com/how_to/how_to_use_fresnelparameters
          */
         useReflectionFresnelFromSpecular: boolean;
         private _useGlossinessFromSpecularMapAlpha;
@@ -29843,6 +30582,10 @@ declare module BABYLON {
          */
         set cameraColorCurves(value: Nullable<ColorCurves>);
         /**
+         * Can this material render to several textures at once
+         */
+        get canRenderToMRT(): boolean;
+        /**
          * Defines the detail map parameters for the material.
          */
         readonly detailMap: DetailMapConfiguration;
@@ -29855,7 +30598,7 @@ declare module BABYLON {
          * Instantiates a new standard material.
          * This is the default material used in Babylon. It is the best trade off between quality
          * and performances.
-         * @see http://doc.babylonjs.com/babylon101/materials
+         * @see https://doc.babylonjs.com/babylon101/materials
          * @param name Define the name of the material in the scene
          * @param scene Define the scene the material belong to
          */
@@ -29873,7 +30616,7 @@ declare module BABYLON {
         /**
          * In case the depth buffer does not allow enough depth precision for your scene (might be the case in large scenes)
          * You can try switching to logarithmic depth.
-         * @see http://doc.babylonjs.com/how_to/using_logarithmic_depth_buffer
+         * @see https://doc.babylonjs.com/how_to/using_logarithmic_depth_buffer
          */
         get useLogarithmicDepth(): boolean;
         set useLogarithmicDepth(value: boolean);
@@ -30028,7 +30771,7 @@ declare module BABYLON {
      * The SPS is also a particle system. It provides some methods to manage the particles.
      * However it is behavior agnostic. This means it has no emitter, no particle physics, no particle recycler. You have to implement your own behavior.
      *
-     * Full documentation here : http://doc.babylonjs.com/how_to/Solid_Particle_System
+     * Full documentation here : https://doc.babylonjs.com/how_to/Solid_Particle_System
      */
     export class SolidParticleSystem implements IDisposable {
         /**
@@ -30062,7 +30805,7 @@ declare module BABYLON {
         mesh: Mesh;
         /**
          * This empty object is intended to store some SPS specific or temporary values in order to lower the Garbage Collector activity.
-         * Please read : http://doc.babylonjs.com/how_to/Solid_Particle_System#garbage-collector-concerns
+         * Please read : https://doc.babylonjs.com/how_to/Solid_Particle_System#garbage-collector-concerns
          */
         vars: any;
         /**
@@ -30074,7 +30817,7 @@ declare module BABYLON {
          * This array is the first element of the pickedBySubMesh array : sps.pickBySubMesh[0].
          * It's not pertinent to use it when using a SPS with the support for MultiMaterial enabled.
          * Use the method SPS.pickedParticle(pickingInfo) instead.
-         * Please read : http://doc.babylonjs.com/how_to/Solid_Particle_System#pickable-particles
+         * Please read : https://doc.babylonjs.com/how_to/Solid_Particle_System#pickable-particles
          */
         pickedParticles: {
             idx: number;
@@ -30089,7 +30832,7 @@ declare module BABYLON {
          * `idx` is the picked particle index in the `SPS.particles` array
          * `faceId` is the picked face index counted within this particle.
          * It's better to use the method SPS.pickedParticle(pickingInfo) rather than using directly this array.
-         * Please read : http://doc.babylonjs.com/how_to/Solid_Particle_System#pickable-particles
+         * Please read : https://doc.babylonjs.com/how_to/Solid_Particle_System#pickable-particles
          */
         pickedBySubMesh: {
             idx: number;
@@ -30268,7 +31011,7 @@ declare module BABYLON {
         private _addParticle;
         /**
          * Adds some particles to the SPS from the model shape. Returns the shape id.
-         * Please read the doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#create-an-immutable-sps
+         * Please read the doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#create-an-immutable-sps
          * @param mesh is any Mesh object that will be used as a model for the solid particles.
          * @param nb (positive integer) the number of particles to be created from this model
          * @param options {positionFunction} is an optional javascript function to called for each particle on SPS creation.
@@ -30405,7 +31148,7 @@ declare module BABYLON {
         private _setDefaultMaterial;
         /**
          * Visibilty helper : Recomputes the visible size according to the mesh bounding box
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
          * @returns the SPS.
          */
         refreshVisibleSize(): SolidParticleSystem;
@@ -30413,27 +31156,27 @@ declare module BABYLON {
          * Visibility helper : Sets the size of a visibility box, this sets the underlying mesh bounding box.
          * @param size the size (float) of the visibility box
          * note : this doesn't lock the SPS mesh bounding box.
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
          */
         setVisibilityBox(size: number): void;
         /**
          * Gets whether the SPS as always visible or not
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
          */
         get isAlwaysVisible(): boolean;
         /**
          * Sets the SPS as always visible or not
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
          */
         set isAlwaysVisible(val: boolean);
         /**
          * Sets the SPS visibility box as locked or not. This enables/disables the underlying mesh bounding box updates.
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
          */
         set isVisibilityBoxLocked(val: boolean);
         /**
          * Gets if the SPS visibility box as locked or not. This enables/disables the underlying mesh bounding box updates.
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#sps-visibility
          */
         get isVisibilityBoxLocked(): boolean;
         /**
@@ -30535,13 +31278,13 @@ declare module BABYLON {
         /**
          * This function does nothing. It may be overwritten to set all the particle first values.
          * The SPS doesn't call this function, you may have to call it by your own.
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#particle-management
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#particle-management
          */
         initParticles(): void;
         /**
          * This function does nothing. It may be overwritten to recycle a particle.
          * The SPS doesn't call this function, you may have to call it by your own.
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#particle-management
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#particle-management
          * @param particle The particle to recycle
          * @returns the recycled particle
          */
@@ -30549,7 +31292,7 @@ declare module BABYLON {
         /**
          * Updates a particle : this function should  be overwritten by the user.
          * It is called on each particle by `setParticles()`. This is the place to code each particle behavior.
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#particle-management
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#particle-management
          * @example : just set a particle position or velocity and recycle conditions
          * @param particle The particle to update
          * @returns the updated particle
@@ -30561,7 +31304,7 @@ declare module BABYLON {
          * @param particle the current particle
          * @param vertex the current vertex of the current particle : a SolidParticleVertex object
          * @param pt the index of the current vertex in the particle shape
-         * doc : http://doc.babylonjs.com/how_to/Solid_Particle_System#update-each-particle-shape
+         * doc : https://doc.babylonjs.com/how_to/Solid_Particle_System#update-each-particle-shape
          * @example : just set a vertex particle position or color
          * @returns the sps
          */
@@ -31043,19 +31786,19 @@ declare module BABYLON {
         cullingStrategy: number;
         /**
          * Gets the number of facets in the mesh
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata#what-is-a-mesh-facet
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata#what-is-a-mesh-facet
          */
         get facetNb(): number;
         /**
          * Gets or set the number (integer) of subdivisions per axis in the partioning space
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata#tweaking-the-partitioning
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata#tweaking-the-partitioning
          */
         get partitioningSubdivisions(): number;
         set partitioningSubdivisions(nb: number);
         /**
          * The ratio (float) to apply to the bouding box size to set to the partioning space.
          * Ex : 1.01 (default) the partioning space is 1% bigger than the bounding box
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata#tweaking-the-partitioning
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata#tweaking-the-partitioning
          */
         get partitioningBBoxRatio(): number;
         set partitioningBBoxRatio(ratio: number);
@@ -31063,7 +31806,7 @@ declare module BABYLON {
          * Gets or sets a boolean indicating that the facets must be depth sorted on next call to `updateFacetData()`.
          * Works only for updatable meshes.
          * Doesn't work with multi-materials
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata#facet-depth-sort
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata#facet-depth-sort
          */
         get mustDepthSortFacets(): boolean;
         set mustDepthSortFacets(sort: boolean);
@@ -31071,13 +31814,13 @@ declare module BABYLON {
          * The location (Vector3) where the facet depth sort must be computed from.
          * By default, the active camera position.
          * Used only when facet depth sort is enabled
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata#facet-depth-sort
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata#facet-depth-sort
          */
         get facetDepthSortFrom(): Vector3;
         set facetDepthSortFrom(location: Vector3);
         /**
          * gets a boolean indicating if facetData is enabled
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata#what-is-a-mesh-facet
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata#what-is-a-mesh-facet
          */
         get isFacetDataEnabled(): boolean;
         /** @hidden */
@@ -31115,7 +31858,7 @@ declare module BABYLON {
          */
         set visibility(value: number);
         /** Gets or sets the alpha index used to sort transparent meshes
-         * @see http://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered#alpha-index
+         * @see https://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered#alpha-index
          */
         alphaIndex: number;
         /**
@@ -31129,7 +31872,7 @@ declare module BABYLON {
         /** Gets or sets a boolean indicating that bounding boxes of subMeshes must be rendered as well (false by default) */
         showSubMeshesBoundingBox: boolean;
         /** Gets or sets a boolean indicating if the mesh must be considered as a ray blocker for lens flares (false by default)
-         * @see http://doc.babylonjs.com/how_to/how_to_use_lens_flares
+         * @see https://doc.babylonjs.com/how_to/how_to_use_lens_flares
          */
         isBlocker: boolean;
         /**
@@ -31138,7 +31881,7 @@ declare module BABYLON {
         enablePointerMoveEvents: boolean;
         /**
          * Specifies the rendering group id for this mesh (0 by default)
-         * @see http://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered#rendering-groups
+         * @see https://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered#rendering-groups
          */
         renderingGroupId: number;
         private _material;
@@ -31147,7 +31890,7 @@ declare module BABYLON {
         set material(value: Nullable<Material>);
         /**
          * Gets or sets a boolean indicating that this mesh can receive realtime shadows
-         * @see http://doc.babylonjs.com/babylon101/shadows
+         * @see https://doc.babylonjs.com/babylon101/shadows
          */
         get receiveShadows(): boolean;
         set receiveShadows(value: boolean);
@@ -31184,7 +31927,7 @@ declare module BABYLON {
         useOctreeForCollisions: boolean;
         /**
          * Gets or sets the current layer mask (default is 0x0FFFFFFF)
-         * @see http://doc.babylonjs.com/how_to/layermasks_and_multi-cam_textures
+         * @see https://doc.babylonjs.com/how_to/layermasks_and_multi-cam_textures
          */
         get layerMask(): number;
         set layerMask(value: number);
@@ -31198,18 +31941,18 @@ declare module BABYLON {
         doNotSyncBoundingInfo: boolean;
         /**
          * Gets or sets the current action manager
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions
          */
         actionManager: Nullable<AbstractActionManager>;
         private _meshCollisionData;
         /**
          * Gets or sets the ellipsoid used to impersonate this mesh when using collision engine (default is (0.5, 1, 0.5))
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
          */
         ellipsoid: Vector3;
         /**
          * Gets or sets the ellipsoid offset used to impersonate this mesh when using collision engine (default is (0, 0, 0))
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
          */
         ellipsoidOffset: Vector3;
         /**
@@ -31255,7 +31998,7 @@ declare module BABYLON {
         _renderId: number;
         /**
          * Gets or sets the list of subMeshes
-         * @see http://doc.babylonjs.com/how_to/multi_materials
+         * @see https://doc.babylonjs.com/how_to/multi_materials
          */
         subMeshes: SubMesh[];
         /** @hidden */
@@ -31280,7 +32023,7 @@ declare module BABYLON {
         _transformMatrixTexture: Nullable<RawTexture>;
         /**
          * Gets or sets a skeleton to apply skining transformations
-         * @see http://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons
+         * @see https://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons
          */
         set skeleton(value: Nullable<Skeleton>);
         get skeleton(): Nullable<Skeleton>;
@@ -31565,18 +32308,18 @@ declare module BABYLON {
         intersectsPoint(point: Vector3): boolean;
         /**
          * Gets or sets a boolean indicating that this mesh can be used in the collision engine
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
          */
         get checkCollisions(): boolean;
         set checkCollisions(collisionEnabled: boolean);
         /**
          * Gets Collider object used to compute collisions (not physics)
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
          */
         get collider(): Nullable<Collider>;
         /**
          * Move the mesh using collision engine
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
          * @param displacement defines the requested displacement vector
          * @returns the current mesh
          */
@@ -31597,7 +32340,7 @@ declare module BABYLON {
          * @param trianglePredicate defines an optional predicate used to select faces when a mesh intersection is detected
          * @param onlyBoundingInfo defines a boolean indicating if picking should only happen using bounding info (false by default)
          * @returns the picking info
-         * @see http://doc.babylonjs.com/babylon101/intersect_collisions_-_mesh
+         * @see https://doc.babylonjs.com/babylon101/intersect_collisions_-_mesh
          */
         intersects(ray: Ray, fastCheck?: boolean, trianglePredicate?: TrianglePickingPredicate, onlyBoundingInfo?: boolean): PickingInfo;
         /**
@@ -31638,27 +32381,27 @@ declare module BABYLON {
          * This method can be called within the render loop.
          * You don't need to call this method by yourself in the render loop when you update/morph a mesh with the methods CreateXXX() as they automatically manage this computation
          * @returns the current mesh
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         updateFacetData(): AbstractMesh;
         /**
          * Returns the facetLocalNormals array.
          * The normals are expressed in the mesh local spac
          * @returns an array of Vector3
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetLocalNormals(): Vector3[];
         /**
          * Returns the facetLocalPositions array.
          * The facet positions are expressed in the mesh local space
          * @returns an array of Vector3
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetLocalPositions(): Vector3[];
         /**
          * Returns the facetLocalPartioning array
          * @returns an array of array of numbers
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetLocalPartitioning(): number[][];
         /**
@@ -31666,7 +32409,7 @@ declare module BABYLON {
          * This method allocates a new Vector3 per call
          * @param i defines the facet index
          * @returns a new Vector3
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetPosition(i: number): Vector3;
         /**
@@ -31674,7 +32417,7 @@ declare module BABYLON {
          * @param i defines the facet index
          * @param ref defines the target vector
          * @returns the current mesh
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetPositionToRef(i: number, ref: Vector3): AbstractMesh;
         /**
@@ -31682,7 +32425,7 @@ declare module BABYLON {
          * This method allocates a new Vector3 per call
          * @param i defines the facet index
          * @returns a new Vector3
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetNormal(i: number): Vector3;
         /**
@@ -31690,7 +32433,7 @@ declare module BABYLON {
          * @param i defines the facet index
          * @param ref defines the target vector
          * @returns the current mesh
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetNormalToRef(i: number, ref: Vector3): this;
         /**
@@ -31699,7 +32442,7 @@ declare module BABYLON {
          * @param y defines y coordinate
          * @param z defines z coordinate
          * @returns the array of facet indexes
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetsAtLocalCoordinates(x: number, y: number, z: number): Nullable<number[]>;
         /**
@@ -31711,7 +32454,7 @@ declare module BABYLON {
          * @param y defines y coordinate
          * @param z defines z coordinate
          * @returns the face index if found (or null instead)
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getClosestFacetAtCoordinates(x: number, y: number, z: number, projected?: Vector3, checkFace?: boolean, facing?: boolean): Nullable<number>;
         /**
@@ -31723,19 +32466,19 @@ declare module BABYLON {
          * @param y defines y coordinate
          * @param z defines z coordinate
          * @returns the face index if found (or null instead)
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getClosestFacetAtLocalCoordinates(x: number, y: number, z: number, projected?: Vector3, checkFace?: boolean, facing?: boolean): Nullable<number>;
         /**
          * Returns the object "parameter" set with all the expected parameters for facetData computation by ComputeNormals()
          * @returns the parameters
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         getFacetDataParameters(): any;
         /**
          * Disables the feature FacetData and frees the related memory
          * @returns the current mesh
-         * @see http://doc.babylonjs.com/how_to/how_to_use_facetdata
+         * @see https://doc.babylonjs.com/how_to/how_to_use_facetdata
          */
         disableFacetData(): AbstractMesh;
         /**
@@ -31877,7 +32620,7 @@ declare module BABYLON {
     /**
      * Abstract class used to decouple action Manager from scene and meshes.
      * Do not instantiate.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export abstract class AbstractActionManager implements IDisposable {
         /** Gets the list of active triggers */
@@ -32120,7 +32863,7 @@ declare module BABYLON {
         private _behaviors;
         /**
          * Attach a behavior to the node
-         * @see http://doc.babylonjs.com/features/behaviour
+         * @see https://doc.babylonjs.com/features/behaviour
          * @param behavior defines the behavior to attach
          * @param attachImmediately defines that the behavior must be attached even if the scene is still loading
          * @returns the current Node
@@ -32128,20 +32871,20 @@ declare module BABYLON {
         addBehavior(behavior: Behavior<Node>, attachImmediately?: boolean): Node;
         /**
          * Remove an attached behavior
-         * @see http://doc.babylonjs.com/features/behaviour
+         * @see https://doc.babylonjs.com/features/behaviour
          * @param behavior defines the behavior to attach
          * @returns the current Node
          */
         removeBehavior(behavior: Behavior<Node>): Node;
         /**
          * Gets the list of attached behaviors
-         * @see http://doc.babylonjs.com/features/behaviour
+         * @see https://doc.babylonjs.com/features/behaviour
          */
         get behaviors(): Behavior<Node>[];
         /**
          * Gets an attached behavior by name
          * @param name defines the name of the behavior to look for
-         * @see http://doc.babylonjs.com/features/behaviour
+         * @see https://doc.babylonjs.com/features/behaviour
          * @returns null if behavior was not found else the requested behavior
          */
         getBehaviorByName(name: string): Nullable<Behavior<Node>>;
@@ -33232,6 +33975,10 @@ declare module BABYLON {
          * If provided, will be called two times with the vertex and fragment code so that this code can be updated before it is compiled by the GPU
          */
         processFinalCode?: Nullable<(shaderType: string, code: string) => string>;
+        /**
+         * Is this effect rendering to several color attachments ?
+         */
+        multiTarget?: boolean;
     }
     /**
      * Effect containing vertex and fragment shader that can be executed on an object.
@@ -33291,6 +34038,8 @@ declare module BABYLON {
         get onBindObservable(): Observable<Effect>;
         /** @hidden */
         _bonesComputationForcedToCPU: boolean;
+        /** @hidden */
+        _multiTarget: boolean;
         private static _uniqueIdSeed;
         private _engine;
         private _uniformBuffersNames;
@@ -33614,7 +34363,7 @@ declare module BABYLON {
          * @param matrices matrices to be set.
          * @returns this effect.
          */
-        setMatrices(uniformName: string, matrices: Float32Array): Effect;
+        setMatrices(uniformName: string, matrices: Float32Array | Array<number>): Effect;
         /**
          * Sets matrix on a uniform variable.
          * @param uniformName Name of the variable.
@@ -33628,14 +34377,14 @@ declare module BABYLON {
          * @param matrix matrix to be set.
          * @returns this effect.
          */
-        setMatrix3x3(uniformName: string, matrix: Float32Array): Effect;
+        setMatrix3x3(uniformName: string, matrix: Float32Array | Array<number>): Effect;
         /**
          * Sets a 2x2 matrix on a uniform variable. (Speicified as [1,2,3,4] will result in [1,2][3,4] matrix)
          * @param uniformName Name of the variable.
          * @param matrix matrix to be set.
          * @returns this effect.
          */
-        setMatrix2x2(uniformName: string, matrix: Float32Array): Effect;
+        setMatrix2x2(uniformName: string, matrix: Float32Array | Array<number>): Effect;
         /**
          * Sets a float on a uniform variable.
          * @param uniformName Name of the variable.
@@ -34184,22 +34933,22 @@ declare module BABYLON {
         limitDeviceRatio?: number;
         /**
          * Defines if webvr should be enabled automatically
-         * @see http://doc.babylonjs.com/how_to/webvr_camera
+         * @see https://doc.babylonjs.com/how_to/webvr_camera
          */
         autoEnableWebVR?: boolean;
         /**
          * Defines if webgl2 should be turned off even if supported
-         * @see http://doc.babylonjs.com/features/webgl2
+         * @see https://doc.babylonjs.com/features/webgl2
          */
         disableWebGL2Support?: boolean;
         /**
          * Defines if webaudio should be initialized as well
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
          */
         audioEngine?: boolean;
         /**
          * Defines if animations should run using a deterministic lock step
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          */
         deterministicLockstep?: boolean;
         /** Defines the maximum steps to use with deterministic lock step mode */
@@ -34224,6 +34973,10 @@ declare module BABYLON {
          * Make the canvas XR Compatible for XR sessions
          */
         xrCompatible?: boolean;
+        /**
+         * Make the matrix computations to be performed in 64 bits instead of 32 bits. False by default
+         */
+        useHighPrecisionMatrix?: boolean;
     }
     /**
      * The base engine class (root of all engines)
@@ -34301,7 +35054,7 @@ declare module BABYLON {
         _uniformBuffers: UniformBuffer[];
         /**
          * Gets a boolean indicating that the engine supports uniform buffers
-         * @see http://doc.babylonjs.com/features/webgl2#uniform-buffer-objets
+         * @see https://doc.babylonjs.com/features/webgl2#uniform-buffer-objets
          */
         get supportsUniformBuffers(): boolean;
         /** @hidden */
@@ -34349,7 +35102,7 @@ declare module BABYLON {
         _doNotHandleContextLost: boolean;
         /**
          * Gets or sets a boolean indicating if resources should be retained to be able to handle context lost events
-         * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#handling-webgl-context-lost
+         * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#handling-webgl-context-lost
          */
         get doNotHandleContextLost(): boolean;
         set doNotHandleContextLost(value: boolean);
@@ -34680,7 +35433,7 @@ declare module BABYLON {
         private _bindVertexBuffersAttributes;
         /**
          * Records a vertex array object
-         * @see http://doc.babylonjs.com/features/webgl2#vertex-array-objects
+         * @see https://doc.babylonjs.com/features/webgl2#vertex-array-objects
          * @param vertexBuffers defines the list of vertex buffers to store
          * @param indexBuffer defines the index buffer to store
          * @param effect defines the effect to store
@@ -34691,7 +35444,7 @@ declare module BABYLON {
         }, indexBuffer: Nullable<DataBuffer>, effect: Effect): WebGLVertexArrayObject;
         /**
          * Bind a specific vertex array object
-         * @see http://doc.babylonjs.com/features/webgl2#vertex-array-objects
+         * @see https://doc.babylonjs.com/features/webgl2#vertex-array-objects
          * @param vertexArrayObject defines the vertex array object to bind
          * @param indexBuffer defines the index buffer to bind
          */
@@ -35615,6 +36368,8 @@ declare module BABYLON {
         /** @hidden */
         _attachments: Nullable<number[]>;
         /** @hidden */
+        _textureArray: Nullable<InternalTexture[]>;
+        /** @hidden */
         _cachedCoordinatesMode: Nullable<number>;
         /** @hidden */
         _cachedWrapU: Nullable<number>;
@@ -35703,7 +36458,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to work with sound analyzer using fast fourier transform (FFT)
-     * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+     * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
      */
     export class Analyser {
         /**
@@ -35799,7 +36554,7 @@ declare module BABYLON {
     /**
      * This represents an audio engine and it is responsible
      * to play, synchronize and analyse sounds throughout the application.
-     * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+     * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
      */
     export interface IAudioEngine extends IDisposable {
         /**
@@ -35867,7 +36622,7 @@ declare module BABYLON {
         /**
          * Connect the audio engine to an audio analyser allowing some amazing
          * synchornization between the sounds/music and your visualization (VuMeter for instance).
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#using-the-analyser
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#using-the-analyser
          * @param analyser The analyser to connect to the engine
          */
         connectToAnalyser(analyser: Analyser): void;
@@ -35875,7 +36630,7 @@ declare module BABYLON {
     /**
      * This represents the default audio engine used in babylon.
      * It is responsible to play, synchronize and analyse sounds throughout the  application.
-     * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+     * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
      */
     export class AudioEngine implements IAudioEngine {
         private _audioContext;
@@ -35971,7 +36726,7 @@ declare module BABYLON {
         /**
          * Connect the audio engine to an audio analyser allowing some amazing
          * synchornization between the sounds/music and your visualization (VuMeter for instance).
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#using-the-analyser
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#using-the-analyser
          * @param analyser The analyser to connect to the engine
          */
         connectToAnalyser(analyser: Analyser): void;
@@ -35980,7 +36735,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Interface used to present a loading screen while loading a scene
-     * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+     * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
      */
     export interface ILoadingScreen {
         /**
@@ -36002,7 +36757,7 @@ declare module BABYLON {
     }
     /**
      * Class used for the default loading screen
-     * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+     * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
      */
     export class DefaultLoadingScreen implements ILoadingScreen {
         private _renderingCanvas;
@@ -36268,12 +37023,12 @@ declare module BABYLON {
              * Sets the current alpha mode
              * @param mode defines the mode to use (one of the Engine.ALPHA_XXX)
              * @param noDepthWriteChange defines if depth writing state should remains unchanged (false by default)
-             * @see http://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
+             * @see https://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
              */
             setAlphaMode(mode: number, noDepthWriteChange?: boolean): void;
             /**
              * Gets the current alpha mode
-             * @see http://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
+             * @see https://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
              * @returns the current alpha mode
              */
             getAlphaMode(): number;
@@ -36603,7 +37358,7 @@ declare module BABYLON {
         onAfterShaderCompilationObservable: Observable<Engine>;
         /**
          * Gets the audio engine
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
          * @ignorenaming
          */
         static audioEngine: IAudioEngine;
@@ -36637,7 +37392,7 @@ declare module BABYLON {
         private _performanceMonitor;
         /**
          * Gets the performance monitor attached to this engine
-         * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#engineinstrumentation
+         * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#engineinstrumentation
          */
         get performanceMonitor(): PerformanceMonitor;
         private _onFocus;
@@ -36684,13 +37439,13 @@ declare module BABYLON {
         getInputElementClientRect(): Nullable<ClientRect>;
         /**
          * Gets a boolean indicating that the engine is running in deterministic lock step mode
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          * @returns true if engine is in deterministic lock step mode
          */
         isDeterministicLockStep(): boolean;
         /**
          * Gets the max steps when engine is running in deterministic lock step
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          * @returns the max steps
          */
         getLockstepMaxSteps(): number;
@@ -36916,7 +37671,7 @@ declare module BABYLON {
         /**
          * Call this function to leave webVR mode
          * Will do nothing if webVR is not supported or if there is no webVR device
-         * @see http://doc.babylonjs.com/how_to/webvr_camera
+         * @see https://doc.babylonjs.com/how_to/webvr_camera
          */
         disableVR(): void;
         /**
@@ -37047,7 +37802,7 @@ declare module BABYLON {
         updateDynamicIndexBuffer(indexBuffer: DataBuffer, indices: IndicesArray, offset?: number): void;
         /**
          * Updates the sample count of a render target texture
-         * @see http://doc.babylonjs.com/features/webgl2#multisample-render-targets
+         * @see https://doc.babylonjs.com/features/webgl2#multisample-render-targets
          * @param texture defines the texture to update
          * @param samples defines the sample count to set
          * @returns the effective sample count (could be 0 if multisample render targets are not supported)
@@ -37079,32 +37834,32 @@ declare module BABYLON {
         private _disableTouchAction;
         /**
          * Display the loading screen
-         * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+         * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
          */
         displayLoadingUI(): void;
         /**
          * Hide the loading screen
-         * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+         * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
          */
         hideLoadingUI(): void;
         /**
          * Gets the current loading screen object
-         * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+         * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
          */
         get loadingScreen(): ILoadingScreen;
         /**
          * Sets the current loading screen object
-         * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+         * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
          */
         set loadingScreen(loadingScreen: ILoadingScreen);
         /**
          * Sets the current loading screen text
-         * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+         * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
          */
         set loadingUIText(text: string);
         /**
          * Sets the current loading screen background color
-         * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+         * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
          */
         set loadingUIBackgroundColor(color: string);
         /** Pointerlock and fullscreen */
@@ -37513,7 +38268,7 @@ declare module BABYLON {
         static Download(blob: Blob, fileName: string): void;
         /**
          * Captures a screenshot of the current rendering
-         * @see http://doc.babylonjs.com/how_to/render_scene_on_a_png
+         * @see https://doc.babylonjs.com/how_to/render_scene_on_a_png
          * @param engine defines the rendering engine
          * @param camera defines the source camera
          * @param size This parameter can be set to a single number or to an object with the
@@ -37530,7 +38285,7 @@ declare module BABYLON {
         static CreateScreenshot(engine: Engine, camera: Camera, size: IScreenshotSize | number, successCallback?: (data: string) => void, mimeType?: string): void;
         /**
          * Captures a screenshot of the current rendering
-         * @see http://doc.babylonjs.com/how_to/render_scene_on_a_png
+         * @see https://doc.babylonjs.com/how_to/render_scene_on_a_png
          * @param engine defines the rendering engine
          * @param camera defines the source camera
          * @param size This parameter can be set to a single number or to an object with the
@@ -37546,7 +38301,7 @@ declare module BABYLON {
         static CreateScreenshotAsync(engine: Engine, camera: Camera, size: IScreenshotSize | number, mimeType?: string): Promise<string>;
         /**
          * Generates an image screenshot from the specified camera.
-         * @see http://doc.babylonjs.com/how_to/render_scene_on_a_png
+         * @see https://doc.babylonjs.com/how_to/render_scene_on_a_png
          * @param engine The engine to use for rendering
          * @param camera The camera to use for rendering
          * @param size This parameter can be set to a single number or to an object with the
@@ -37566,7 +38321,7 @@ declare module BABYLON {
         static CreateScreenshotUsingRenderTarget(engine: Engine, camera: Camera, size: IScreenshotSize | number, successCallback?: (data: string) => void, mimeType?: string, samples?: number, antialiasing?: boolean, fileName?: string): void;
         /**
          * Generates an image screenshot from the specified camera.
-         * @see http://doc.babylonjs.com/how_to/render_scene_on_a_png
+         * @see https://doc.babylonjs.com/how_to/render_scene_on_a_png
          * @param engine The engine to use for rendering
          * @param camera The camera to use for rendering
          * @param size This parameter can be set to a single number or to an object with the
@@ -38162,7 +38917,7 @@ declare module BABYLON {
         /**
          * Instantiates a new Animation Group.
          * This helps managing several animations at once.
-         * @see http://doc.babylonjs.com/how_to/group
+         * @see https://doc.babylonjs.com/how_to/group
          * @param name Defines the name of the group
          * @param scene Defines the scene the group belongs to
          */
@@ -38228,14 +38983,14 @@ declare module BABYLON {
          * Set animation weight for all animatables
          * @param weight defines the weight to use
          * @return the animationGroup
-         * @see http://doc.babylonjs.com/babylon101/animations#animation-weights
+         * @see https://doc.babylonjs.com/babylon101/animations#animation-weights
          */
         setWeightForAllAnimatables(weight: number): AnimationGroup;
         /**
          * Synchronize and normalize all animatables with a source animatable
          * @param root defines the root animatable to synchronize with
          * @return the animationGroup
-         * @see http://doc.babylonjs.com/babylon101/animations#animation-weights
+         * @see https://doc.babylonjs.com/babylon101/animations#animation-weights
          */
         syncAllAnimationsWith(root: Animatable): AnimationGroup;
         /**
@@ -38323,7 +39078,7 @@ declare module BABYLON {
     }
     /**
      * Represents a scene to be rendered by the engine.
-     * @see http://doc.babylonjs.com/features/scene
+     * @see https://doc.babylonjs.com/features/scene
      */
     export class Scene extends AbstractScene implements IAnimatable {
         /** The fog is deactivated */
@@ -38336,12 +39091,12 @@ declare module BABYLON {
         static readonly FOGMODE_LINEAR: number;
         /**
          * Gets or sets the minimum deltatime when deterministic lock step is enabled
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          */
         static MinDeltaTime: number;
         /**
          * Gets or sets the maximum deltatime when deterministic lock step is enabled
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          */
         static MaxDeltaTime: number;
         /**
@@ -38797,26 +39552,26 @@ declare module BABYLON {
         private _currentInternalStep;
         /**
          * Sets the step Id used by deterministic lock step
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          * @param newStepId defines the step Id
          */
         setStepId(newStepId: number): void;
         /**
          * Gets the step Id used by deterministic lock step
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          * @returns the step Id
          */
         getStepId(): number;
         /**
          * Gets the internal step used by deterministic lock step
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          * @returns the internal step
          */
         getInternalStep(): number;
         private _fogEnabled;
         /**
         * Gets or sets a boolean indicating if fog is enabled on this scene
-        * @see http://doc.babylonjs.com/babylon101/environment#fog
+        * @see https://doc.babylonjs.com/babylon101/environment#fog
         * (Default is true)
         */
         set fogEnabled(value: boolean);
@@ -38824,7 +39579,7 @@ declare module BABYLON {
         private _fogMode;
         /**
         * Gets or sets the fog mode to use
-        * @see http://doc.babylonjs.com/babylon101/environment#fog
+        * @see https://doc.babylonjs.com/babylon101/environment#fog
         * | mode | value |
         * | --- | --- |
         * | FOGMODE_NONE | 0 |
@@ -38836,28 +39591,32 @@ declare module BABYLON {
         get fogMode(): number;
         /**
         * Gets or sets the fog color to use
-        * @see http://doc.babylonjs.com/babylon101/environment#fog
+        * @see https://doc.babylonjs.com/babylon101/environment#fog
         * (Default is Color3(0.2, 0.2, 0.3))
         */
         fogColor: Color3;
         /**
         * Gets or sets the fog density to use
-        * @see http://doc.babylonjs.com/babylon101/environment#fog
+        * @see https://doc.babylonjs.com/babylon101/environment#fog
         * (Default is 0.1)
         */
         fogDensity: number;
         /**
         * Gets or sets the fog start distance to use
-        * @see http://doc.babylonjs.com/babylon101/environment#fog
+        * @see https://doc.babylonjs.com/babylon101/environment#fog
         * (Default is 0)
         */
         fogStart: number;
         /**
         * Gets or sets the fog end distance to use
-        * @see http://doc.babylonjs.com/babylon101/environment#fog
+        * @see https://doc.babylonjs.com/babylon101/environment#fog
         * (Default is 1000)
         */
         fogEnd: number;
+        /**
+        * Flag indicating that the frame buffer binding is handled by another component
+        */
+        prePass: boolean;
         private _shadowsEnabled;
         /**
         * Gets or sets a boolean indicating if shadows are enabled on this scene
@@ -38912,7 +39671,7 @@ declare module BABYLON {
         lensFlaresEnabled: boolean;
         /**
         * Gets or sets a boolean indicating if collisions are enabled on this scene
-        * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
+        * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
         */
         collisionsEnabled: boolean;
         private _collisionCoordinator;
@@ -38920,7 +39679,7 @@ declare module BABYLON {
         get collisionCoordinator(): ICollisionCoordinator;
         /**
          * Defines the gravity applied to this scene (used only for collisions)
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity
          */
         gravity: Vector3;
         /**
@@ -38963,12 +39722,12 @@ declare module BABYLON {
         probesEnabled: boolean;
         /**
          * Gets or sets the current offline provider to use to store scene data
-         * @see http://doc.babylonjs.com/how_to/caching_resources_in_indexeddb
+         * @see https://doc.babylonjs.com/how_to/caching_resources_in_indexeddb
          */
         offlineProvider: IOfflineProvider;
         /**
          * Gets or sets the action manager associated with the scene
-         * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+         * @see https://doc.babylonjs.com/how_to/how_to_use_actions
         */
         actionManager: AbstractActionManager;
         private _meshesForIntersections;
@@ -39269,7 +40028,7 @@ declare module BABYLON {
         getTotalVertices(): number;
         /**
          * Gets the performance counter for total vertices
-         * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#instrumentation
+         * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#instrumentation
          */
         get totalVerticesPerfCounter(): PerfCounter;
         /**
@@ -39279,7 +40038,7 @@ declare module BABYLON {
         getActiveIndices(): number;
         /**
          * Gets the performance counter for active indices
-         * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#instrumentation
+         * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#instrumentation
          */
         get totalActiveIndicesPerfCounter(): PerfCounter;
         /**
@@ -39289,7 +40048,7 @@ declare module BABYLON {
         getActiveParticles(): number;
         /**
          * Gets the performance counter for active particles
-         * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#instrumentation
+         * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#instrumentation
          */
         get activeParticlesPerfCounter(): PerfCounter;
         /**
@@ -39299,7 +40058,7 @@ declare module BABYLON {
         getActiveBones(): number;
         /**
          * Gets the performance counter for active bones
-         * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#instrumentation
+         * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#instrumentation
          */
         get activeBonesPerfCounter(): PerfCounter;
         /**
@@ -40351,12 +41110,12 @@ declare module BABYLON {
          */
         rootNodes: Node[];
         /** All of the cameras added to this scene
-         * @see http://doc.babylonjs.com/babylon101/cameras
+         * @see https://doc.babylonjs.com/babylon101/cameras
          */
         cameras: Camera[];
         /**
         * All of the lights added to this scene
-        * @see http://doc.babylonjs.com/babylon101/lights
+        * @see https://doc.babylonjs.com/babylon101/lights
         */
         lights: Light[];
         /**
@@ -40365,12 +41124,12 @@ declare module BABYLON {
         meshes: AbstractMesh[];
         /**
          * The list of skeletons added to the scene
-         * @see http://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons
+         * @see https://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons
          */
         skeletons: Skeleton[];
         /**
         * All of the particle systems added to this scene
-        * @see http://doc.babylonjs.com/babylon101/particles
+        * @see https://doc.babylonjs.com/babylon101/particles
         */
         particleSystems: IParticleSystem[];
         /**
@@ -40379,12 +41138,12 @@ declare module BABYLON {
         animations: Animation[];
         /**
         * All of the animation groups added to this scene
-        * @see http://doc.babylonjs.com/how_to/group
+        * @see https://doc.babylonjs.com/how_to/group
         */
         animationGroups: AnimationGroup[];
         /**
         * All of the multi-materials added to this scene
-        * @see http://doc.babylonjs.com/how_to/multi_materials
+        * @see https://doc.babylonjs.com/how_to/multi_materials
         */
         multiMaterials: MultiMaterial[];
         /**
@@ -40392,12 +41151,12 @@ declare module BABYLON {
         * In the context of a Scene, it is not supposed to be modified manually.
         * Any addition or removal should be done using the addMaterial and removeMaterial Scene methods.
         * Note also that the order of the Material within the array is not significant and might change.
-        * @see http://doc.babylonjs.com/babylon101/materials
+        * @see https://doc.babylonjs.com/babylon101/materials
         */
         materials: Material[];
         /**
          * The list of morph target managers added to the scene
-         * @see http://doc.babylonjs.com/how_to/how_to_dynamically_morph_a_mesh
+         * @see https://doc.babylonjs.com/how_to/how_to_dynamically_morph_a_mesh
          */
         morphTargetManagers: MorphTargetManager[];
         /**
@@ -40409,7 +41168,7 @@ declare module BABYLON {
         * In the context of a Scene, it is not supposed to be modified manually.
         * Any addition or removal should be done using the addTransformNode and removeTransformNode Scene methods.
         * Note also that the order of the TransformNode wihin the array is not significant and might change.
-        * @see http://doc.babylonjs.com/how_to/transformnode
+        * @see https://doc.babylonjs.com/how_to/transformnode
         */
         transformNodes: TransformNode[];
         /**
@@ -40461,17 +41220,17 @@ declare module BABYLON {
         useCustomAttenuation?: boolean;
         /**
         * Define the roll off factor of spatial sounds.
-        * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+        * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
         */
         rolloffFactor?: number;
         /**
          * Define the reference distance the sound should be heard perfectly.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         refDistance?: number;
         /**
          * Define the distance attenuation model the sound will follow.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         distanceModel?: string;
         /**
@@ -40498,7 +41257,7 @@ declare module BABYLON {
     /**
      * Defines a sound that can be played in the application.
      * The sound can either be an ambient track or a simple sound played in reaction to a user action.
-     * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+     * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
      */
     export class Sound {
         /**
@@ -40516,7 +41275,7 @@ declare module BABYLON {
         /**
          * Does the sound use a custom attenuation curve to simulate the falloff
          * happening when the source gets further away from the camera.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-your-own-custom-attenuation-function
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-your-own-custom-attenuation-function
          */
         useCustomAttenuation: boolean;
         /**
@@ -40533,27 +41292,27 @@ declare module BABYLON {
         isPaused: boolean;
         /**
          * Does this sound enables spatial sound.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         spatialSound: boolean;
         /**
          * Define the reference distance the sound should be heard perfectly.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         refDistance: number;
         /**
          * Define the roll off factor of spatial sounds.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         rolloffFactor: number;
         /**
          * Define the max distance the sound should be heard (intensity just became 0 at this point).
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         maxDistance: number;
         /**
          * Define the distance attenuation model the sound will follow.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         distanceModel: string;
         /**
@@ -40637,13 +41396,13 @@ declare module BABYLON {
         /**
          * Switch the panning model to HRTF:
          * Renders a stereo output of higher quality than equalpower — it uses a convolution with measured impulse responses from human subjects.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         switchPanningModelToHRTF(): void;
         /**
          * Switch the panning model to Equal Power:
          * Represents the equal-power panning algorithm, generally regarded as simple and efficient. equalpower is the default value.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         switchPanningModelToEqualPower(): void;
         private _switchPanningModel;
@@ -40691,7 +41450,7 @@ declare module BABYLON {
         /**
          * Sets a new custom attenuation function for the sound.
          * @param callback Defines the function used for the attenuation
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-your-own-custom-attenuation-function
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-your-own-custom-attenuation-function
          */
         setAttenuationFunction(callback: (currentVolume: number, currentDistance: number, maxDistance: number, refDistance: number, rolloffFactor: number) => number): void;
         /**
@@ -40730,12 +41489,12 @@ declare module BABYLON {
         /**
          * Attach the sound to a dedicated mesh
          * @param transformNode The transform node to connect the sound with
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#attaching-a-sound-to-a-mesh
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#attaching-a-sound-to-a-mesh
          */
         attachToMesh(transformNode: TransformNode): void;
         /**
          * Detach the sound from the previously attached mesh
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#attaching-a-sound-to-a-mesh
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#attaching-a-sound-to-a-mesh
          */
         detachFromMesh(): void;
         private _onRegisterAfterWorldMatrixUpdate;
@@ -40831,7 +41590,7 @@ declare module BABYLON {
     /**
      * This defines an action responsible to change the value of a property
      * by interpolating between its current value and the newly set one once triggered.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_actions
+     * @see https://doc.babylonjs.com/how_to/how_to_use_actions
      */
     export class InterpolateValueAction extends Action {
         /**
@@ -40904,7 +41663,7 @@ declare module BABYLON {
     /**
      * It could be useful to isolate your music & sounds on several tracks to better manage volume on a grouped instance of sounds.
      * It will be also used in a future release to apply effects on a specific track.
-     * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#using-sound-tracks
+     * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#using-sound-tracks
      */
     export class SoundTrack {
         /**
@@ -40922,7 +41681,7 @@ declare module BABYLON {
         private _isInitialized;
         /**
          * Creates a new sound track.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#using-sound-tracks
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#using-sound-tracks
          * @param scene Define the scene the sound track belongs to
          * @param options
          */
@@ -40952,19 +41711,19 @@ declare module BABYLON {
         /**
          * Switch the panning model to HRTF:
          * Renders a stereo output of higher quality than equalpower — it uses a convolution with measured impulse responses from human subjects.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         switchPanningModelToHRTF(): void;
         /**
          * Switch the panning model to Equal Power:
          * Represents the equal-power panning algorithm, generally regarded as simple and efficient. equalpower is the default value.
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#creating-a-spatial-3d-sound
          */
         switchPanningModelToEqualPower(): void;
         /**
          * Connect the sound track to an audio analyser allowing some amazing
          * synchornization between the sounds/music and your visualization (VuMeter for instance).
-         * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music#using-the-analyser
+         * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music#using-the-analyser
          * @param analyser The analyser to connect to the engine
          */
         connectToAnalyser(analyser: Analyser): void;
@@ -40990,7 +41749,7 @@ declare module BABYLON {
             mainSoundTrack: SoundTrack;
             /**
              * The list of sound tracks added to the scene
-             * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+             * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
              */
             soundTracks: Nullable<Array<SoundTrack>>;
             /**
@@ -41001,17 +41760,17 @@ declare module BABYLON {
             getSoundByName(name: string): Nullable<Sound>;
             /**
              * Gets or sets if audio support is enabled
-             * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+             * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
              */
             audioEnabled: boolean;
             /**
              * Gets or sets if audio will be output to headphones
-             * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+             * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
              */
             headphone: boolean;
             /**
              * Gets or sets custom audio listener position provider
-             * @see http://doc.babylonjs.com/how_to/playing_sounds_and_music
+             * @see https://doc.babylonjs.com/how_to/playing_sounds_and_music
              */
             audioListenerPositionProvider: Nullable<() => Vector3>;
             /**
@@ -41183,7 +41942,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Add a bouncing effect to an ArcRotateCamera when reaching a specified minimum and maximum radius
-     * @see http://doc.babylonjs.com/how_to/camera_behaviors#bouncing-behavior
+     * @see https://doc.babylonjs.com/how_to/camera_behaviors#bouncing-behavior
      */
     export class BouncingBehavior implements Behavior<ArcRotateCamera> {
         /**
@@ -41264,7 +42023,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * The framing behavior (FramingBehavior) is designed to automatically position an ArcRotateCamera when its target is set to a mesh. It is also useful if you want to prevent the camera to go under a virtual horizontal plane.
-     * @see http://doc.babylonjs.com/how_to/camera_behaviors#framing-behavior
+     * @see https://doc.babylonjs.com/how_to/camera_behaviors#framing-behavior
      */
     export class FramingBehavior implements Behavior<ArcRotateCamera> {
         /**
@@ -41552,7 +42311,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the pointers inputs to control an arc rotate camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class ArcRotateCameraPointersInput extends BaseCameraPointersInput {
         /**
@@ -41647,7 +42406,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the keyboard inputs to control the movement of an arc rotate camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateCamera> {
         /**
@@ -41732,7 +42491,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the mouse wheel inputs to control an arc rotate camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class ArcRotateCameraMouseWheelInput implements ICameraInput<ArcRotateCamera> {
         /**
@@ -41778,7 +42537,7 @@ declare module BABYLON {
     /**
      * Default Inputs manager for the ArcRotateCamera.
      * It groups all the default supported inputs for ease of use.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class ArcRotateCameraInputsManager extends CameraInputsManager<ArcRotateCamera> {
         /**
@@ -41809,7 +42568,7 @@ declare module BABYLON {
      *
      * This camera always points towards a given target position and can be rotated around that target with the target as the centre of rotation. It can be controlled with cursors and mouse, or with touch events.
      * Think of this camera as one orbiting its target position, or more imaginatively as a spy satellite orbiting the earth. Its position relative to the target (earth) can be set by three parameters, alpha (radians) the longitudinal rotation, beta (radians) the latitudinal rotation and radius the distance from the target position.
-     * @see http://doc.babylonjs.com/babylon101/cameras#arc-rotate-camera
+     * @see https://doc.babylonjs.com/babylon101/cameras#arc-rotate-camera
      */
     export class ArcRotateCamera extends TargetCamera {
         /**
@@ -42030,36 +42789,36 @@ declare module BABYLON {
         private _bouncingBehavior;
         /**
          * Gets the bouncing behavior of the camera if it has been enabled.
-         * @see http://doc.babylonjs.com/how_to/camera_behaviors#bouncing-behavior
+         * @see https://doc.babylonjs.com/how_to/camera_behaviors#bouncing-behavior
          */
         get bouncingBehavior(): Nullable<BouncingBehavior>;
         /**
          * Defines if the bouncing behavior of the camera is enabled on the camera.
-         * @see http://doc.babylonjs.com/how_to/camera_behaviors#bouncing-behavior
+         * @see https://doc.babylonjs.com/how_to/camera_behaviors#bouncing-behavior
          */
         get useBouncingBehavior(): boolean;
         set useBouncingBehavior(value: boolean);
         private _framingBehavior;
         /**
          * Gets the framing behavior of the camera if it has been enabled.
-         * @see http://doc.babylonjs.com/how_to/camera_behaviors#framing-behavior
+         * @see https://doc.babylonjs.com/how_to/camera_behaviors#framing-behavior
          */
         get framingBehavior(): Nullable<FramingBehavior>;
         /**
          * Defines if the framing behavior of the camera is enabled on the camera.
-         * @see http://doc.babylonjs.com/how_to/camera_behaviors#framing-behavior
+         * @see https://doc.babylonjs.com/how_to/camera_behaviors#framing-behavior
          */
         get useFramingBehavior(): boolean;
         set useFramingBehavior(value: boolean);
         private _autoRotationBehavior;
         /**
          * Gets the auto rotation behavior of the camera if it has been enabled.
-         * @see http://doc.babylonjs.com/how_to/camera_behaviors#autorotation-behavior
+         * @see https://doc.babylonjs.com/how_to/camera_behaviors#autorotation-behavior
          */
         get autoRotationBehavior(): Nullable<AutoRotationBehavior>;
         /**
          * Defines if the auto rotation behavior of the camera is enabled on the camera.
-         * @see http://doc.babylonjs.com/how_to/camera_behaviors#autorotation-behavior
+         * @see https://doc.babylonjs.com/how_to/camera_behaviors#autorotation-behavior
          */
         get useAutoRotationBehavior(): boolean;
         set useAutoRotationBehavior(value: boolean);
@@ -42073,13 +42832,13 @@ declare module BABYLON {
         onCollide: (collidedMesh: AbstractMesh) => void;
         /**
          * Defines whether the camera should check collision with the objects oh the scene.
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity#how-can-i-do-this
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity#how-can-i-do-this
          */
         checkCollisions: boolean;
         /**
          * Defines the collision radius of the camera.
          * This simulates a sphere around the camera.
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity#arcrotatecamera
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity#arcrotatecamera
          */
         collisionRadius: Vector3;
         protected _collider: Collider;
@@ -42204,7 +42963,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * The autoRotation behavior (AutoRotationBehavior) is designed to create a smooth rotation of an ArcRotateCamera when there is no user interaction.
-     * @see http://doc.babylonjs.com/how_to/camera_behaviors#autorotation-behavior
+     * @see https://doc.babylonjs.com/how_to/camera_behaviors#autorotation-behavior
      */
     export class AutoRotationBehavior implements Behavior<ArcRotateCamera> {
         /**
@@ -42585,10 +43344,7 @@ declare module BABYLON {
         private _moveDrag;
         private _pickWithRayOnDragPlane;
         private _pointA;
-        private _pointB;
         private _pointC;
-        private _lineA;
-        private _lineB;
         private _localAxis;
         private _lookAt;
         private _updateDragPlanePosition;
@@ -42712,7 +43468,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to apply inverse kinematics to bones
-     * @see http://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons#boneikcontroller
+     * @see https://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons#boneikcontroller
      */
     export class BoneIKController {
         private static _tmpVecs;
@@ -42796,7 +43552,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to make a bone look toward a point in space
-     * @see http://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons#bonelookcontroller
+     * @see https://doc.babylonjs.com/how_to/how_to_use_bones_and_skeletons#bonelookcontroller
      */
     export class BoneLookController {
         private static _tmpVecs;
@@ -42921,7 +43677,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the gamepad inputs to control an arc rotate camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class ArcRotateCameraGamepadInput implements ICameraInput<ArcRotateCamera> {
         /**
@@ -42988,7 +43744,7 @@ declare module BABYLON {
         }
     /**
      * Manage the device orientation inputs (gyroscope) to control an arc rotate camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class ArcRotateCameraVRDeviceOrientationInput implements ICameraInput<ArcRotateCamera> {
         /**
@@ -43044,7 +43800,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Listen to mouse events to control the camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FlyCameraMouseInput implements ICameraInput<FlyCamera> {
         /**
@@ -43093,7 +43849,7 @@ declare module BABYLON {
         /**
          * Listen to mouse events to control the camera.
          * @param touchEnabled Define if touch is enabled. (Default is true.)
-         * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+         * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
          */
         constructor(touchEnabled?: boolean);
         /**
@@ -43129,7 +43885,7 @@ declare module BABYLON {
     /**
      * Default Inputs manager for the FlyCamera.
      * It groups all the default supported inputs for ease of use.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FlyCameraInputsManager extends CameraInputsManager<FlyCamera> {
         /**
@@ -43159,7 +43915,7 @@ declare module BABYLON {
         /**
          * Define the collision ellipsoid of the camera.
          * This is helpful for simulating a camera body, like a player's body.
-         * @see http://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity#arcrotatecamera
+         * @see https://doc.babylonjs.com/babylon101/cameras,_mesh_collisions_and_gravity#arcrotatecamera
          */
         ellipsoid: Vector3;
         /**
@@ -43340,7 +44096,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Listen to keyboard events to control the camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FlyCameraKeyboardInput implements ICameraInput<FlyCamera> {
         /**
@@ -43409,7 +44165,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the mouse wheel inputs to control a follow camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FollowCameraMouseWheelInput implements ICameraInput<FollowCamera> {
         /**
@@ -43466,7 +44222,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the pointers inputs to control an follow camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FollowCameraPointersInput extends BaseCameraPointersInput {
         /**
@@ -43552,7 +44308,7 @@ declare module BABYLON {
     /**
      * Default Inputs manager for the FollowCamera.
      * It groups all the default supported inputs for ease of use.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FollowCameraInputsManager extends CameraInputsManager<FollowCamera> {
         /**
@@ -43586,7 +44342,7 @@ declare module BABYLON {
     /**
      * A follow camera takes a mesh as a target and follows it as it moves. Both a free camera version followCamera and
      * an arc rotate version arcFollowCamera are available.
-     * @see http://doc.babylonjs.com/features/cameras#follow-camera
+     * @see https://doc.babylonjs.com/features/cameras#follow-camera
      */
     export class FollowCamera extends TargetCamera {
         /**
@@ -43652,7 +44408,7 @@ declare module BABYLON {
         inputs: FollowCameraInputsManager;
         /**
          * Instantiates the follow camera.
-         * @see http://doc.babylonjs.com/features/cameras#follow-camera
+         * @see https://doc.babylonjs.com/features/cameras#follow-camera
          * @param name Define the name of the camera in the scene
          * @param position Define the position of the camera
          * @param scene Define the scene the camera belong to
@@ -43684,7 +44440,7 @@ declare module BABYLON {
     /**
      * Arc Rotate version of the follow camera.
      * It still follows a Defined mesh but in an Arc Rotate Camera fashion.
-     * @see http://doc.babylonjs.com/features/cameras#follow-camera
+     * @see https://doc.babylonjs.com/features/cameras#follow-camera
      */
     export class ArcFollowCamera extends TargetCamera {
         /** The longitudinal angle of the camera */
@@ -43698,7 +44454,7 @@ declare module BABYLON {
         private _cartesianCoordinates;
         /**
          * Instantiates a new ArcFollowCamera
-         * @see http://doc.babylonjs.com/features/cameras#follow-camera
+         * @see https://doc.babylonjs.com/features/cameras#follow-camera
          * @param name Define the name of the camera
          * @param alpha Define the rotation angle of the camera around the logitudinal axis
          * @param beta Define the rotation angle of the camera around the elevation axis
@@ -43728,7 +44484,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the keyboard inputs to control the movement of a follow camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FollowCameraKeyboardMoveInput implements ICameraInput<FollowCamera> {
         /**
@@ -43873,7 +44629,7 @@ declare module BABYLON {
     /**
      * Takes information about the orientation of the device as reported by the deviceorientation event to orient the camera.
      * Screen rotation is taken into account.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FreeCameraDeviceOrientationInput implements ICameraInput<FreeCamera> {
         private _camera;
@@ -43895,7 +44651,7 @@ declare module BABYLON {
         _onDeviceOrientationChangedObservable: Observable<void>;
         /**
          * Instantiates a new input
-         * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+         * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
          */
         constructor();
         /**
@@ -43936,7 +44692,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Manage the gamepad inputs to control a free camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FreeCameraGamepadInput implements ICameraInput<FreeCamera> {
         /**
@@ -44210,7 +44966,7 @@ declare module BABYLON {
         }
     /**
      * Manage the Virtual Joystick inputs to control the movement of a free camera.
-     * @see http://doc.babylonjs.com/how_to/customizing_camera_inputs
+     * @see https://doc.babylonjs.com/how_to/customizing_camera_inputs
      */
     export class FreeCameraVirtualJoystickInput implements ICameraInput<FreeCamera> {
         /**
@@ -44261,7 +45017,7 @@ declare module BABYLON {
     /**
      * This represents a FPS type of camera controlled by touch.
      * This is like a universal camera minus the Gamepad controls.
-     * @see http://doc.babylonjs.com/features/cameras#universal-camera
+     * @see https://doc.babylonjs.com/features/cameras#universal-camera
      */
     export class TouchCamera extends FreeCamera {
         /**
@@ -44280,7 +45036,7 @@ declare module BABYLON {
          * Instantiates a new touch camera.
          * This represents a FPS type of camera controlled by touch.
          * This is like a universal camera minus the Gamepad controls.
-         * @see http://doc.babylonjs.com/features/cameras#universal-camera
+         * @see https://doc.babylonjs.com/features/cameras#universal-camera
          * @param name Define the name of the camera in the scene
          * @param position Define the start position of the camera in the scene
          * @param scene Define the scene the camera belongs to
@@ -44894,7 +45650,7 @@ declare module BABYLON {
             _gamepadManager: Nullable<GamepadManager>;
             /**
              * Gets the gamepad manager associated with the scene
-             * @see http://doc.babylonjs.com/how_to/how_to_use_gamepads
+             * @see https://doc.babylonjs.com/how_to/how_to_use_gamepads
              */
             gamepadManager: GamepadManager;
         }
@@ -44955,7 +45711,7 @@ declare module BABYLON {
     /**
      * The Universal Camera is the one to choose for first person shooter type games, and works with all the keyboard, mouse, touch and gamepads. This replaces the earlier Free Camera,
      * which still works and will still be found in many Playgrounds.
-     * @see http://doc.babylonjs.com/features/cameras#universal-camera
+     * @see https://doc.babylonjs.com/features/cameras#universal-camera
      */
     export class UniversalCamera extends TouchCamera {
         /**
@@ -44973,7 +45729,7 @@ declare module BABYLON {
         /**
          * The Universal Camera is the one to choose for first person shooter type games, and works with all the keyboard, mouse, touch and gamepads. This replaces the earlier Free Camera,
          * which still works and will still be found in many Playgrounds.
-         * @see http://doc.babylonjs.com/features/cameras#universal-camera
+         * @see https://doc.babylonjs.com/features/cameras#universal-camera
          * @param name Define the name of the camera in the scene
          * @param position Define the start position of the camera in the scene
          * @param scene Define the scene the camera belongs to
@@ -44990,14 +45746,14 @@ declare module BABYLON {
     /**
      * This represents a FPS type of camera. This is only here for back compat purpose.
      * Please use the UniversalCamera instead as both are identical.
-     * @see http://doc.babylonjs.com/features/cameras#universal-camera
+     * @see https://doc.babylonjs.com/features/cameras#universal-camera
      */
     export class GamepadCamera extends UniversalCamera {
         /**
          * Instantiates a new Gamepad Camera
          * This represents a FPS type of camera. This is only here for back compat purpose.
          * Please use the UniversalCamera instead as both are identical.
-         * @see http://doc.babylonjs.com/features/cameras#universal-camera
+         * @see https://doc.babylonjs.com/features/cameras#universal-camera
          * @param name Define the name of the camera in the scene
          * @param position Define the start position of the camera in the scene
          * @param scene Define the scene the camera belongs to
@@ -45100,7 +45856,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate anaglyphic rendering (based on ArcRotateCamera)
-     * @see http://doc.babylonjs.com/features/cameras#anaglyph-cameras
+     * @see https://doc.babylonjs.com/features/cameras#anaglyph-cameras
      */
     export class AnaglyphArcRotateCamera extends ArcRotateCamera {
         /**
@@ -45124,7 +45880,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate anaglyphic rendering (based on FreeCamera)
-     * @see http://doc.babylonjs.com/features/cameras#anaglyph-cameras
+     * @see https://doc.babylonjs.com/features/cameras#anaglyph-cameras
      */
     export class AnaglyphFreeCamera extends FreeCamera {
         /**
@@ -45145,7 +45901,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate anaglyphic rendering (based on GamepadCamera)
-     * @see http://doc.babylonjs.com/features/cameras#anaglyph-cameras
+     * @see https://doc.babylonjs.com/features/cameras#anaglyph-cameras
      */
     export class AnaglyphGamepadCamera extends GamepadCamera {
         /**
@@ -45166,7 +45922,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate anaglyphic rendering (based on UniversalCamera)
-     * @see http://doc.babylonjs.com/features/cameras#anaglyph-cameras
+     * @see https://doc.babylonjs.com/features/cameras#anaglyph-cameras
      */
     export class AnaglyphUniversalCamera extends UniversalCamera {
         /**
@@ -45187,7 +45943,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate stereoscopic rendering (based on ArcRotateCamera)
-     * @see http://doc.babylonjs.com/features/cameras
+     * @see https://doc.babylonjs.com/features/cameras
      */
     export class StereoscopicArcRotateCamera extends ArcRotateCamera {
         /**
@@ -45212,7 +45968,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate stereoscopic rendering (based on FreeCamera)
-     * @see http://doc.babylonjs.com/features/cameras
+     * @see https://doc.babylonjs.com/features/cameras
      */
     export class StereoscopicFreeCamera extends FreeCamera {
         /**
@@ -45234,7 +45990,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate stereoscopic rendering (based on GamepadCamera)
-     * @see http://doc.babylonjs.com/features/cameras
+     * @see https://doc.babylonjs.com/features/cameras
      */
     export class StereoscopicGamepadCamera extends GamepadCamera {
         /**
@@ -45256,7 +46012,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate stereoscopic rendering (based on UniversalCamera)
-     * @see http://doc.babylonjs.com/features/cameras
+     * @see https://doc.babylonjs.com/features/cameras
      */
     export class StereoscopicUniversalCamera extends UniversalCamera {
         /**
@@ -45280,14 +46036,14 @@ declare module BABYLON {
      * This represents a free type of camera. It can be useful in First Person Shooter game for instance.
      * It is identical to the Free Camera and simply adds by default a virtual joystick.
      * Virtual Joysticks are on-screen 2D graphics that are used to control the camera or other scene items.
-     * @see http://doc.babylonjs.com/features/cameras#virtual-joysticks-camera
+     * @see https://doc.babylonjs.com/features/cameras#virtual-joysticks-camera
      */
     export class VirtualJoysticksCamera extends FreeCamera {
         /**
          * Intantiates a VirtualJoysticksCamera. It can be useful in First Person Shooter game for instance.
          * It is identical to the Free Camera and simply adds by default a virtual joystick.
          * Virtual Joysticks are on-screen 2D graphics that are used to control the camera or other scene items.
-         * @see http://doc.babylonjs.com/features/cameras#virtual-joysticks-camera
+         * @see https://doc.babylonjs.com/features/cameras#virtual-joysticks-camera
          * @param name Define the name of the camera in the scene
          * @param position Define the start position of the camera in the scene
          * @param scene Define the scene the camera belongs to
@@ -45303,7 +46059,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * This represents all the required metrics to create a VR camera.
-     * @see http://doc.babylonjs.com/babylon101/cameras#device-orientation-camera
+     * @see https://doc.babylonjs.com/babylon101/cameras#device-orientation-camera
      */
     export class VRCameraMetrics {
         /**
@@ -45427,7 +46183,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate VR rendering (based on ArcRotateCamera)
-     * @see http://doc.babylonjs.com/babylon101/cameras#vr-device-orientation-cameras
+     * @see https://doc.babylonjs.com/babylon101/cameras#vr-device-orientation-cameras
      */
     export class VRDeviceOrientationArcRotateCamera extends ArcRotateCamera {
         /**
@@ -45452,7 +46208,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate VR rendering (based on FreeCamera)
-     * @see http://doc.babylonjs.com/babylon101/cameras#vr-device-orientation-cameras
+     * @see https://doc.babylonjs.com/babylon101/cameras#vr-device-orientation-cameras
      */
     export class VRDeviceOrientationFreeCamera extends DeviceOrientationCamera {
         /**
@@ -45474,7 +46230,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Camera used to simulate VR rendering (based on VRDeviceOrientationFreeCamera)
-     * @see http://doc.babylonjs.com/babylon101/cameras#vr-device-orientation-cameras
+     * @see https://doc.babylonjs.com/babylon101/cameras#vr-device-orientation-cameras
      */
     export class VRDeviceOrientationGamepadCamera extends VRDeviceOrientationFreeCamera {
         /**
@@ -45496,7 +46252,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * A class extending Texture allowing drawing on a texture
-     * @see http://doc.babylonjs.com/how_to/dynamictexture
+     * @see https://doc.babylonjs.com/how_to/dynamictexture
      */
     export class DynamicTexture extends Texture {
         private _generateMipMaps;
@@ -45573,195 +46329,6 @@ declare module BABYLON {
         private _IsCanvasElement;
         /** @hidden */
         _rebuild(): void;
-    }
-}
-declare module BABYLON {
-    /** @hidden */
-    export var imageProcessingPixelShader: {
-        name: string;
-        shader: string;
-    };
-}
-declare module BABYLON {
-    /**
-     * ImageProcessingPostProcess
-     * @see https://doc.babylonjs.com/how_to/how_to_use_postprocesses#imageprocessing
-     */
-    export class ImageProcessingPostProcess extends PostProcess {
-        /**
-         * Default configuration related to image processing available in the PBR Material.
-         */
-        protected _imageProcessingConfiguration: ImageProcessingConfiguration;
-        /**
-         * Gets the image processing configuration used either in this material.
-         */
-        get imageProcessingConfiguration(): ImageProcessingConfiguration;
-        /**
-         * Sets the Default image processing configuration used either in the this material.
-         *
-         * If sets to null, the scene one is in use.
-         */
-        set imageProcessingConfiguration(value: ImageProcessingConfiguration);
-        /**
-         * Keep track of the image processing observer to allow dispose and replace.
-         */
-        private _imageProcessingObserver;
-        /**
-         * Attaches a new image processing configuration to the PBR Material.
-         * @param configuration
-         */
-        protected _attachImageProcessingConfiguration(configuration: Nullable<ImageProcessingConfiguration>, doNotBuild?: boolean): void;
-        /**
-         * Gets Color curves setup used in the effect if colorCurvesEnabled is set to true .
-         */
-        get colorCurves(): Nullable<ColorCurves>;
-        /**
-         * Sets Color curves setup used in the effect if colorCurvesEnabled is set to true .
-         */
-        set colorCurves(value: Nullable<ColorCurves>);
-        /**
-         * Gets wether the color curves effect is enabled.
-         */
-        get colorCurvesEnabled(): boolean;
-        /**
-         * Sets wether the color curves effect is enabled.
-         */
-        set colorCurvesEnabled(value: boolean);
-        /**
-         * Gets Color grading LUT texture used in the effect if colorGradingEnabled is set to true.
-         */
-        get colorGradingTexture(): Nullable<BaseTexture>;
-        /**
-         * Sets Color grading LUT texture used in the effect if colorGradingEnabled is set to true.
-         */
-        set colorGradingTexture(value: Nullable<BaseTexture>);
-        /**
-         * Gets wether the color grading effect is enabled.
-         */
-        get colorGradingEnabled(): boolean;
-        /**
-         * Gets wether the color grading effect is enabled.
-         */
-        set colorGradingEnabled(value: boolean);
-        /**
-         * Gets exposure used in the effect.
-         */
-        get exposure(): number;
-        /**
-         * Sets exposure used in the effect.
-         */
-        set exposure(value: number);
-        /**
-         * Gets wether tonemapping is enabled or not.
-         */
-        get toneMappingEnabled(): boolean;
-        /**
-         * Sets wether tonemapping is enabled or not
-         */
-        set toneMappingEnabled(value: boolean);
-        /**
-         * Gets the type of tone mapping effect.
-         */
-        get toneMappingType(): number;
-        /**
-         * Sets the type of tone mapping effect.
-         */
-        set toneMappingType(value: number);
-        /**
-         * Gets contrast used in the effect.
-         */
-        get contrast(): number;
-        /**
-         * Sets contrast used in the effect.
-         */
-        set contrast(value: number);
-        /**
-         * Gets Vignette stretch size.
-         */
-        get vignetteStretch(): number;
-        /**
-         * Sets Vignette stretch size.
-         */
-        set vignetteStretch(value: number);
-        /**
-         * Gets Vignette centre X Offset.
-         */
-        get vignetteCentreX(): number;
-        /**
-         * Sets Vignette centre X Offset.
-         */
-        set vignetteCentreX(value: number);
-        /**
-         * Gets Vignette centre Y Offset.
-         */
-        get vignetteCentreY(): number;
-        /**
-         * Sets Vignette centre Y Offset.
-         */
-        set vignetteCentreY(value: number);
-        /**
-         * Gets Vignette weight or intensity of the vignette effect.
-         */
-        get vignetteWeight(): number;
-        /**
-         * Sets Vignette weight or intensity of the vignette effect.
-         */
-        set vignetteWeight(value: number);
-        /**
-         * Gets Color of the vignette applied on the screen through the chosen blend mode (vignetteBlendMode)
-         * if vignetteEnabled is set to true.
-         */
-        get vignetteColor(): Color4;
-        /**
-         * Sets Color of the vignette applied on the screen through the chosen blend mode (vignetteBlendMode)
-         * if vignetteEnabled is set to true.
-         */
-        set vignetteColor(value: Color4);
-        /**
-         * Gets Camera field of view used by the Vignette effect.
-         */
-        get vignetteCameraFov(): number;
-        /**
-         * Sets Camera field of view used by the Vignette effect.
-         */
-        set vignetteCameraFov(value: number);
-        /**
-         * Gets the vignette blend mode allowing different kind of effect.
-         */
-        get vignetteBlendMode(): number;
-        /**
-         * Sets the vignette blend mode allowing different kind of effect.
-         */
-        set vignetteBlendMode(value: number);
-        /**
-         * Gets wether the vignette effect is enabled.
-         */
-        get vignetteEnabled(): boolean;
-        /**
-         * Sets wether the vignette effect is enabled.
-         */
-        set vignetteEnabled(value: boolean);
-        private _fromLinearSpace;
-        /**
-         * Gets wether the input of the processing is in Gamma or Linear Space.
-         */
-        get fromLinearSpace(): boolean;
-        /**
-         * Sets wether the input of the processing is in Gamma or Linear Space.
-         */
-        set fromLinearSpace(value: boolean);
-        /**
-         * Defines cache preventing GC.
-         */
-        private _defines;
-        constructor(name: string, options: number | PostProcessOptions, camera?: Nullable<Camera>, samplingMode?: number, engine?: Engine, reusable?: boolean, textureType?: number, imageProcessingConfiguration?: ImageProcessingConfiguration);
-        /**
-         *  "ImageProcessingPostProcess"
-         * @returns "ImageProcessingPostProcess"
-         */
-        getClassName(): string;
-        protected _updateParameters(): void;
-        dispose(camera?: Camera): void;
     }
 }
 declare module BABYLON {
@@ -46004,6 +46571,7 @@ declare module BABYLON {
         private _options;
         private _canvas;
         private _engine;
+        private _originalCanvasSize;
         /**
          * Rendering context of the canvas which can be used to display/mirror xr content
          */
@@ -46012,6 +46580,10 @@ declare module BABYLON {
          * xr layer for the canvas
          */
         xrLayer: Nullable<XRWebGLLayer>;
+        /**
+         * Obseervers registered here will be triggered when the xr layer was initialized
+         */
+        onXRLayerInitObservable: Observable<XRWebGLLayer>;
         /**
          * Initializes the canvas to be added/removed upon entering/exiting xr
          * @param _xrSessionManager The XR Session manager
@@ -46030,13 +46602,14 @@ declare module BABYLON {
         initializeXRLayerAsync(xrSession: XRSession): Promise<XRWebGLLayer>;
         private _addCanvas;
         private _removeCanvas;
+        private _setCanvasSize;
         private _setManagedOutputCanvas;
     }
 }
 declare module BABYLON {
     /**
      * Manages an XRSession to work with Babylon's engine
-     * @see https://doc.babylonjs.com/how_to/webxr
+     * @see https://doc.babylonjs.com/how_to/webxr_session_manager
      */
     export class WebXRSessionManager implements IDisposable {
         /** The scene which the session should be created for */
@@ -46215,10 +46788,7 @@ declare module BABYLON {
          * @returns the class name
          */
         getClassName(): string;
-        /**
-         * Overriding the _getViewMatrix function, as it is computed by WebXR
-         */
-        _getViewMatrix(): Matrix;
+        private _rotate180;
         private _updateFromXRSession;
         private _updateNumberOfRigCameras;
         private _updateReferenceSpace;
@@ -46290,7 +46860,7 @@ declare module BABYLON {
     /**
      * Defining the constructor of a feature. Used to register the modules.
      */
-    export type WebXRFeatureConstructor = (xrSessionManager: WebXRSessionManager, options?: any) => (() => IWebXRFeature);
+    export type WebXRFeatureConstructor = (xrSessionManager: WebXRSessionManager, options?: any) => () => IWebXRFeature;
     /**
      * The WebXR features manager is responsible of enabling or disabling features required for the current XR session.
      * It is mainly used in AR sessions.
@@ -46326,7 +46896,7 @@ declare module BABYLON {
          * @param options optional options provided to the module.
          * @returns a function that, when called, will return a new instance of this feature
          */
-        static ConstructFeature(featureName: string, version: number | undefined, xrSessionManager: WebXRSessionManager, options?: any): (() => IWebXRFeature);
+        static ConstructFeature(featureName: string, version: number | undefined, xrSessionManager: WebXRSessionManager, options?: any): () => IWebXRFeature;
         /**
          * Can be used to return the list of features currently registered
          *
@@ -46404,7 +46974,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Base set of functionality needed to create an XR experience (WebXRSessionManager, Camera, StateManagement, etc.)
-     * @see https://doc.babylonjs.com/how_to/webxr
+     * @see https://doc.babylonjs.com/how_to/webxr_experience_helpers
      */
     export class WebXRExperienceHelper implements IDisposable {
         private scene;
@@ -46836,7 +47406,7 @@ declare module BABYLON {
     }
     /**
      * Class used to load scene from various file formats using registered plugins
-     * @see http://doc.babylonjs.com/how_to/load_from_any_file_type
+     * @see https://doc.babylonjs.com/how_to/load_from_any_file_type
      */
     export class SceneLoader {
         /**
@@ -46881,6 +47451,7 @@ declare module BABYLON {
          */
         static OnPluginActivatedObservable: Observable<ISceneLoaderPlugin | ISceneLoaderPluginAsync>;
         private static _registeredPlugins;
+        private static _showingLoadingScreen;
         private static _getDefaultPlugin;
         private static _getPluginForExtension;
         private static _getPluginForDirectLoad;
@@ -47011,8 +47582,9 @@ declare module BABYLON {
          * @param onSuccess a callback with the scene when import succeeds
          * @param onProgress a callback with a progress event for each file being loaded
          * @param onError a callback with the scene, a message, and possibly an exception when import fails
+         * @param pluginExtension the extension used to determine the plugin
          */
-        static ImportAnimations(rootUrl: string, sceneFilename?: string | File, scene?: Nullable<Scene>, overwriteAnimations?: boolean, animationGroupLoadingMode?: SceneLoaderAnimationGroupLoadingMode, targetConverter?: Nullable<(target: any) => any>, onSuccess?: Nullable<(scene: Scene) => void>, onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>, onError?: Nullable<(scene: Scene, message: string, exception?: any) => void>): void;
+        static ImportAnimations(rootUrl: string, sceneFilename?: string | File, scene?: Nullable<Scene>, overwriteAnimations?: boolean, animationGroupLoadingMode?: SceneLoaderAnimationGroupLoadingMode, targetConverter?: Nullable<(target: any) => any>, onSuccess?: Nullable<(scene: Scene) => void>, onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>, onError?: Nullable<(scene: Scene, message: string, exception?: any) => void>, pluginExtension?: Nullable<string>): void;
         /**
          * Import animations from a file into a scene
          * @param rootUrl a string that defines the root url for the scene and resources or the concatenation of rootURL and filename (e.g. http://example.com/test.glb)
@@ -47024,9 +47596,10 @@ declare module BABYLON {
          * @param onSuccess a callback with the scene when import succeeds
          * @param onProgress a callback with a progress event for each file being loaded
          * @param onError a callback with the scene, a message, and possibly an exception when import fails
+         * @param pluginExtension the extension used to determine the plugin
          * @returns the updated scene with imported animations
          */
-        static ImportAnimationsAsync(rootUrl: string, sceneFilename?: string | File, scene?: Nullable<Scene>, overwriteAnimations?: boolean, animationGroupLoadingMode?: SceneLoaderAnimationGroupLoadingMode, targetConverter?: Nullable<(target: any) => any>, onSuccess?: Nullable<(scene: Scene) => void>, onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>, onError?: Nullable<(scene: Scene, message: string, exception?: any) => void>): Promise<Scene>;
+        static ImportAnimationsAsync(rootUrl: string, sceneFilename?: string | File, scene?: Nullable<Scene>, overwriteAnimations?: boolean, animationGroupLoadingMode?: SceneLoaderAnimationGroupLoadingMode, targetConverter?: Nullable<(target: any) => any>, onSuccess?: Nullable<(scene: Scene) => void>, onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>, onError?: Nullable<(scene: Scene, message: string, exception?: any) => void>, pluginExtension?: Nullable<string>): Promise<Scene>;
     }
 }
 declare module BABYLON {
@@ -47217,8 +47790,8 @@ declare module BABYLON {
          */
         buttons: Array<{
             /**
-            * Value of the button/trigger
-            */
+             * Value of the button/trigger
+             */
             value: number;
             /**
              * If the button/trigger is currently touched
@@ -47635,8 +48208,8 @@ declare module BABYLON {
          */
         pointer: AbstractMesh;
         /**
-         * Creates the controller
-         * @see https://doc.babylonjs.com/how_to/webxr
+         * Creates the input source object
+         * @see https://doc.babylonjs.com/how_to/webxr_controllers_support
          * @param _scene the scene which the controller should be associated to
          * @param inputSource the underlying input source for the controller
          * @param _options options for this controller creation
@@ -48100,6 +48673,10 @@ declare module BABYLON {
          * A list of optional features to init the session with
          */
         optionalFeatures?: string[];
+        /**
+         * A list of optional features to init the session with
+         */
+        requiredFeatures?: string[];
     }
     /**
      * UI to allow the user to enter/exit XR mode
@@ -48735,7 +49312,7 @@ declare module BABYLON {
     }
     /**
      * Helps to quickly add VR support to an existing scene.
-     * See http://doc.babylonjs.com/how_to/webvr_helper
+     * See https://doc.babylonjs.com/how_to/webvr_helper
      */
     export class VRExperienceHelper {
         /** Options to modify the vr experience helper's behavior. */
@@ -48883,7 +49460,7 @@ declare module BABYLON {
         /**
          * The mesh used to display where the user is selecting, this mesh will be cloned and set as the gazeTracker for the left and right controller
          * when set bakeCurrentTransformIntoVertices will be called on the mesh.
-         * See http://doc.babylonjs.com/resources/baking_transformations
+         * See https://doc.babylonjs.com/resources/baking_transformations
          */
         get gazeTrackerMesh(): Mesh;
         set gazeTrackerMesh(value: Mesh);
@@ -49102,7 +49679,7 @@ declare module BABYLON {
     }
     /**
      * Class used to store a cell in an octree
-     * @see http://doc.babylonjs.com/how_to/optimizing_your_scene_with_octrees
+     * @see https://doc.babylonjs.com/how_to/optimizing_your_scene_with_octrees
      */
     export class OctreeBlock<T> {
         /**
@@ -49274,12 +49851,12 @@ declare module BABYLON {
             _selectionOctree: Octree<AbstractMesh>;
             /**
              * Gets the octree used to boost mesh selection (picking)
-             * @see http://doc.babylonjs.com/how_to/optimizing_your_scene_with_octrees
+             * @see https://doc.babylonjs.com/how_to/optimizing_your_scene_with_octrees
              */
             selectionOctree: Octree<AbstractMesh>;
             /**
              * Creates or updates the octree used to boost selection (picking)
-             * @see http://doc.babylonjs.com/how_to/optimizing_your_scene_with_octrees
+             * @see https://doc.babylonjs.com/how_to/optimizing_your_scene_with_octrees
              * @param maxCapacity defines the maximum capacity per leaf
              * @param maxDepth defines the maximum depth of the octree
              * @returns an octree of AbstractMesh
@@ -49299,7 +49876,7 @@ declare module BABYLON {
              * @param maxDepth defines the maximum depth to use (no more than 2 levels by default)
              * @returns the new octree
              * @see https://www.babylonjs-playground.com/#NA4OQ#12
-             * @see http://doc.babylonjs.com/how_to/optimizing_your_scene_with_octrees
+             * @see https://doc.babylonjs.com/how_to/optimizing_your_scene_with_octrees
              */
             createOrUpdateSubmeshesOctree(maxCapacity?: number, maxDepth?: number): Octree<SubMesh>;
         }
@@ -49378,6 +49955,7 @@ declare module BABYLON {
          */
         _rootMesh: Mesh;
         private _attachedMesh;
+        private _attachedNode;
         /**
          * Ratio for the scale of the gizmo (Default: 1)
          */
@@ -49392,6 +49970,12 @@ declare module BABYLON {
          */
         get attachedMesh(): Nullable<AbstractMesh>;
         set attachedMesh(value: Nullable<AbstractMesh>);
+        /**
+         * Node that the gizmo will be attached to. (eg. on a drag gizmo the mesh, bone or NodeTransform that will be dragged)
+         * * When set, interactions will be enabled
+         */
+        get attachedNode(): Nullable<Node>;
+        set attachedNode(value: Nullable<Node>);
         /**
          * Disposes and replaces the current meshes in the gizmo with the specified mesh
          * @param mesh The mesh to replace the default mesh of the gizmo
@@ -49410,7 +49994,7 @@ declare module BABYLON {
          */
         updateScale: boolean;
         protected _interactionsEnabled: boolean;
-        protected _attachedMeshChanged(value: Nullable<AbstractMesh>): void;
+        protected _attachedNodeChanged(value: Nullable<Node>): void;
         private _beforeRenderObserver;
         private _tempVector;
         /**
@@ -49424,6 +50008,11 @@ declare module BABYLON {
          * Updates the gizmo to match the attached mesh's position/rotation
          */
         protected _update(): void;
+        /**
+         * computes the rotation/scaling/position of the transform once the Node world matrix has changed.
+         * @param value Node, TransformNode or mesh
+         */
+        protected _matrixChanged(): void;
         /**
          * Disposes of the gizmo
          */
@@ -49467,7 +50056,7 @@ declare module BABYLON {
          * @param color The color of the gizmo
          */
         constructor(dragPlaneNormal: Vector3, color?: Color3, gizmoLayer?: UtilityLayerRenderer, parent?: Nullable<PositionGizmo>);
-        protected _attachedMeshChanged(value: Nullable<AbstractMesh>): void;
+        protected _attachedNodeChanged(value: Nullable<Node>): void;
         /**
          * If the gizmo is enabled
          */
@@ -49512,6 +50101,7 @@ declare module BABYLON {
          * private variables
          */
         private _meshAttached;
+        private _nodeAttached;
         private _updateGizmoRotationToMatchAttachedMesh;
         private _snapDistance;
         private _scaleRatio;
@@ -49525,11 +50115,14 @@ declare module BABYLON {
         private _planarGizmoEnabled;
         get attachedMesh(): Nullable<AbstractMesh>;
         set attachedMesh(mesh: Nullable<AbstractMesh>);
+        get attachedNode(): Nullable<Node>;
+        set attachedNode(node: Nullable<Node>);
         /**
          * Creates a PositionGizmo
          * @param gizmoLayer The utility layer the gizmo will be added to
+          @param thickness display gizmo axis thickness
          */
-        constructor(gizmoLayer?: UtilityLayerRenderer);
+        constructor(gizmoLayer?: UtilityLayerRenderer, thickness?: number);
         /**
          * If the planar drag gizmo is enabled
          * setting this will enable/disable XY, XZ and YZ planes regardless of individual gizmo settings.
@@ -49586,7 +50179,7 @@ declare module BABYLON {
         private _coloredMaterial;
         private _hoverMaterial;
         /** @hidden */
-        static _CreateArrow(scene: Scene, material: StandardMaterial): TransformNode;
+        static _CreateArrow(scene: Scene, material: StandardMaterial, thickness?: number): TransformNode;
         /** @hidden */
         static _CreateArrowInstance(scene: Scene, arrow: TransformNode): TransformNode;
         /**
@@ -49594,9 +50187,10 @@ declare module BABYLON {
          * @param gizmoLayer The utility layer the gizmo will be added to
          * @param dragAxis The axis which the gizmo will be able to drag on
          * @param color The color of the gizmo
+         * @param thickness display gizmo axis thickness
          */
-        constructor(dragAxis: Vector3, color?: Color3, gizmoLayer?: UtilityLayerRenderer, parent?: Nullable<PositionGizmo>);
-        protected _attachedMeshChanged(value: Nullable<AbstractMesh>): void;
+        constructor(dragAxis: Vector3, color?: Color3, gizmoLayer?: UtilityLayerRenderer, parent?: Nullable<PositionGizmo>, thickness?: number);
+        protected _attachedNodeChanged(value: Nullable<Node>): void;
         /**
          * If the gizmo is enabled
          */
@@ -49782,7 +50376,7 @@ declare module BABYLON {
             _debugLayer: DebugLayer;
             /**
              * Gets the debug layer (aka Inspector) associated with the scene
-             * @see http://doc.babylonjs.com/features/playground_debuglayer
+             * @see https://doc.babylonjs.com/features/playground_debuglayer
              */
             debugLayer: DebugLayer;
         }
@@ -49814,7 +50408,7 @@ declare module BABYLON {
     /**
      * The debug layer (aka Inspector) is the go to tool in order to better understand
      * what is happening in your scene
-     * @see http://doc.babylonjs.com/features/playground_debuglayer
+     * @see https://doc.babylonjs.com/features/playground_debuglayer
      */
     export class DebugLayer {
         /**
@@ -49834,7 +50428,7 @@ declare module BABYLON {
          * Instantiates a new debug layer.
          * The debug layer (aka Inspector) is the go to tool in order to better understand
          * what is happening in your scene
-         * @see http://doc.babylonjs.com/features/playground_debuglayer
+         * @see https://doc.babylonjs.com/features/playground_debuglayer
          * @param scene Defines the scene to inspect
          */
         constructor(scene: Scene);
@@ -49961,7 +50555,7 @@ declare module BABYLON {
     /**
      * As raycast might be hard to debug, the RayHelper can help rendering the different rays
      * in order to better appreciate the issue one might have.
-     * @see http://doc.babylonjs.com/babylon101/raycasts#debugging
+     * @see https://doc.babylonjs.com/babylon101/raycasts#debugging
      */
     export class RayHelper {
         /**
@@ -49988,7 +50582,7 @@ declare module BABYLON {
          * Instantiate a new ray helper.
          * As raycast might be hard to debug, the RayHelper can help rendering the different rays
          * in order to better appreciate the issue one might have.
-         * @see http://doc.babylonjs.com/babylon101/raycasts#debugging
+         * @see https://doc.babylonjs.com/babylon101/raycasts#debugging
          * @param ray Defines the ray we are currently tryin to visualize
          */
         constructor(ray: Ray);
@@ -50506,6 +51100,10 @@ declare module BABYLON {
          * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          */
         lockstepMaxSteps: number;
+        /**
+         * Make the matrix computations to be performed in 64 bits instead of 32 bits. False by default
+         */
+        useHighPrecisionMatrix?: boolean;
     }
     /**
      * The null engine class provides support for headless version of babylon.js.
@@ -50515,13 +51113,13 @@ declare module BABYLON {
         private _options;
         /**
          * Gets a boolean indicating that the engine is running in deterministic lock step mode
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          * @returns true if engine is in deterministic lock step mode
          */
         isDeterministicLockStep(): boolean;
         /**
          * Gets the max steps when engine is running in deterministic lock step
-         * @see http://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
+         * @see https://doc.babylonjs.com/babylon101/animations#deterministic-lockstep
          * @returns the max steps
          */
         getLockstepMaxSteps(): number;
@@ -50736,7 +51334,7 @@ declare module BABYLON {
          * Sets the current alpha mode
          * @param mode defines the mode to use (one of the Engine.ALPHA_XXX)
          * @param noDepthWriteChange defines if depth writing state should remains unchanged (false by default)
-         * @see http://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
+         * @see https://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
          */
         setAlphaMode(mode: number, noDepthWriteChange?: boolean): void;
         /**
@@ -50959,12 +51557,12 @@ declare module BABYLON {
              * @param algorithmType defines the algorithm to use
              * @param query defines the query to use
              * @returns the current engine
-             * @see http://doc.babylonjs.com/features/occlusionquery
+             * @see https://doc.babylonjs.com/features/occlusionquery
              */
             beginOcclusionQuery(algorithmType: number, query: WebGLQuery): Engine;
             /**
              * Ends an occlusion query
-             * @see http://doc.babylonjs.com/features/occlusionquery
+             * @see https://doc.babylonjs.com/features/occlusionquery
              * @param algorithmType defines the algorithm to use
              * @returns the current engine
              */
@@ -51008,7 +51606,7 @@ declare module BABYLON {
             /**
             * This number indicates the number of allowed retries before stop the occlusion query, this is useful if the occlusion query is taking long time before to the query result is retireved, the query result indicates if the object is visible within the scene or not and based on that Babylon.Js engine decideds to show or hide the object.
             * The default value is -1 which means don't break the query and wait till the result
-            * @see http://doc.babylonjs.com/features/occlusionquery
+            * @see https://doc.babylonjs.com/features/occlusionquery
             */
             occlusionRetryCount: number;
             /**
@@ -51016,24 +51614,24 @@ declare module BABYLON {
              * * OCCLUSION_TYPE_NONE (Default Value): this option means no occlusion query whith the Mesh.
              * * OCCLUSION_TYPE_OPTIMISTIC: this option is means use occlusion query and if occlusionRetryCount is reached and the query is broken show the mesh.
              * * OCCLUSION_TYPE_STRICT: this option is means use occlusion query and if occlusionRetryCount is reached and the query is broken restore the last state of the mesh occlusion if the mesh was visible then show the mesh if was hidden then hide don't show.
-             * @see http://doc.babylonjs.com/features/occlusionquery
+             * @see https://doc.babylonjs.com/features/occlusionquery
              */
             occlusionType: number;
             /**
             * This property determines the type of occlusion query algorithm to run in WebGl, you can use:
             * * AbstractMesh.OCCLUSION_ALGORITHM_TYPE_ACCURATE which is mapped to GL_ANY_SAMPLES_PASSED.
             * * AbstractMesh.OCCLUSION_ALGORITHM_TYPE_CONSERVATIVE (Default Value) which is mapped to GL_ANY_SAMPLES_PASSED_CONSERVATIVE which is a false positive algorithm that is faster than GL_ANY_SAMPLES_PASSED but less accurate.
-            * @see http://doc.babylonjs.com/features/occlusionquery
+            * @see https://doc.babylonjs.com/features/occlusionquery
             */
             occlusionQueryAlgorithmType: number;
             /**
             * Gets or sets whether the mesh is occluded or not, it is used also to set the intial state of the mesh to be occluded or not
-            * @see http://doc.babylonjs.com/features/occlusionquery
+            * @see https://doc.babylonjs.com/features/occlusionquery
             */
             isOccluded: boolean;
             /**
              * Flag to check the progress status of the query
-             * @see http://doc.babylonjs.com/features/occlusionquery
+             * @see https://doc.babylonjs.com/features/occlusionquery
              */
             isOcclusionQueryInProgress: boolean;
         }
@@ -51078,147 +51676,6 @@ declare module BABYLON {
              * @param value defines the webGL buffer to bind
              */
             bindTransformFeedbackBuffer(value: Nullable<DataBuffer>): void;
-        }
-}
-declare module BABYLON {
-    /**
-     * Creation options of the multi render target texture.
-     */
-    export interface IMultiRenderTargetOptions {
-        /**
-         * Define if the texture needs to create mip maps after render.
-         */
-        generateMipMaps?: boolean;
-        /**
-         * Define the types of all the draw buffers we want to create
-         */
-        types?: number[];
-        /**
-         * Define the sampling modes of all the draw buffers we want to create
-         */
-        samplingModes?: number[];
-        /**
-         * Define if a depth buffer is required
-         */
-        generateDepthBuffer?: boolean;
-        /**
-         * Define if a stencil buffer is required
-         */
-        generateStencilBuffer?: boolean;
-        /**
-         * Define if a depth texture is required instead of a depth buffer
-         */
-        generateDepthTexture?: boolean;
-        /**
-         * Define the number of desired draw buffers
-         */
-        textureCount?: number;
-        /**
-         * Define if aspect ratio should be adapted to the texture or stay the scene one
-         */
-        doNotChangeAspectRatio?: boolean;
-        /**
-         * Define the default type of the buffers we are creating
-         */
-        defaultType?: number;
-    }
-    /**
-     * A multi render target, like a render target provides the ability to render to a texture.
-     * Unlike the render target, it can render to several draw buffers in one draw.
-     * This is specially interesting in deferred rendering or for any effects requiring more than
-     * just one color from a single pass.
-     */
-    export class MultiRenderTarget extends RenderTargetTexture {
-        private _internalTextures;
-        private _textures;
-        private _multiRenderTargetOptions;
-        /**
-         * Get if draw buffers are currently supported by the used hardware and browser.
-         */
-        get isSupported(): boolean;
-        /**
-         * Get the list of textures generated by the multi render target.
-         */
-        get textures(): Texture[];
-        /**
-         * Get the depth texture generated by the multi render target if options.generateDepthTexture has been set
-         */
-        get depthTexture(): Texture;
-        /**
-         * Set the wrapping mode on U of all the textures we are rendering to.
-         * Can be any of the Texture. (CLAMP_ADDRESSMODE, MIRROR_ADDRESSMODE or WRAP_ADDRESSMODE)
-         */
-        set wrapU(wrap: number);
-        /**
-         * Set the wrapping mode on V of all the textures we are rendering to.
-         * Can be any of the Texture. (CLAMP_ADDRESSMODE, MIRROR_ADDRESSMODE or WRAP_ADDRESSMODE)
-         */
-        set wrapV(wrap: number);
-        /**
-         * Instantiate a new multi render target texture.
-         * A multi render target, like a render target provides the ability to render to a texture.
-         * Unlike the render target, it can render to several draw buffers in one draw.
-         * This is specially interesting in deferred rendering or for any effects requiring more than
-         * just one color from a single pass.
-         * @param name Define the name of the texture
-         * @param size Define the size of the buffers to render to
-         * @param count Define the number of target we are rendering into
-         * @param scene Define the scene the texture belongs to
-         * @param options Define the options used to create the multi render target
-         */
-        constructor(name: string, size: any, count: number, scene: Scene, options?: IMultiRenderTargetOptions);
-        /** @hidden */
-        _rebuild(): void;
-        private _createInternalTextures;
-        private _createTextures;
-        /**
-         * Define the number of samples used if MSAA is enabled.
-         */
-        get samples(): number;
-        set samples(value: number);
-        /**
-         * Resize all the textures in the multi render target.
-         * Be carrefull as it will recreate all the data in the new texture.
-         * @param size Define the new size
-         */
-        resize(size: any): void;
-        protected unbindFrameBuffer(engine: Engine, faceIndex: number): void;
-        /**
-         * Dispose the render targets and their associated resources
-         */
-        dispose(): void;
-        /**
-         * Release all the underlying texture used as draw buffers.
-         */
-        releaseInternalTextures(): void;
-    }
-}
-declare module BABYLON {
-        interface ThinEngine {
-            /**
-             * Unbind a list of render target textures from the webGL context
-             * This is used only when drawBuffer extension or webGL2 are active
-             * @param textures defines the render target textures to unbind
-             * @param disableGenerateMipMaps defines a boolean indicating that mipmaps must not be generated
-             * @param onBeforeUnbind defines a function which will be called before the effective unbind
-             */
-            unBindMultiColorAttachmentFramebuffer(textures: InternalTexture[], disableGenerateMipMaps: boolean, onBeforeUnbind?: () => void): void;
-            /**
-             * Create a multi render target texture
-             * @see http://doc.babylonjs.com/features/webgl2#multiple-render-target
-             * @param size defines the size of the texture
-             * @param options defines the creation options
-             * @returns the cube texture as an InternalTexture
-             */
-            createMultipleRenderTarget(size: any, options: IMultiRenderTargetOptions): InternalTexture[];
-            /**
-             * Update the sample count for a given multiple render target texture
-             * @see http://doc.babylonjs.com/features/webgl2#multisample-render-targets
-             * @param textures defines the textures to update
-             * @param samples defines the sample count to set
-             * @returns the effective sample count (could be 0 if multisample render targets are not supported)
-             */
-            updateMultipleRenderTargetTextureSampleCount(textures: Nullable<InternalTexture[]>, samples: number): number;
         }
 }
 declare module BABYLON {
@@ -51550,23 +52007,6 @@ declare module BABYLON {
     }
 }
 declare module BABYLON {
-    /** @hidden */
-    export class NativeShaderProcessor extends WebGL2ShaderProcessor {
-        private _genericAttributeLocation;
-        private _varyingLocationCount;
-        private _varyingLocationMap;
-        private _replacements;
-        private _textureCount;
-        private _uniforms;
-        lineProcessor(line: string): string;
-        attributeProcessor(attribute: string): string;
-        varyingProcessor(varying: string, isFragment: boolean): string;
-        uniformProcessor(uniform: string): string;
-        preProcessor(code: string, defines: string[], isFragment: boolean): string;
-        postProcessor(code: string, defines: string[], isFragment: boolean): string;
-    }
-}
-declare module BABYLON {
     /**
      * Class used to inline functions in shader code
     */
@@ -51738,12 +52178,12 @@ declare module BABYLON {
          * Sets the current alpha mode
          * @param mode defines the mode to use (one of the BABYLON.Constants.ALPHA_XXX)
          * @param noDepthWriteChange defines if depth writing state should remains unchanged (false by default)
-         * @see http://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
+         * @see https://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
          */
         setAlphaMode(mode: number, noDepthWriteChange?: boolean): void;
         /**
          * Gets the current alpha mode
-         * @see http://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
+         * @see https://doc.babylonjs.com/resources/transparency_and_how_meshes_are_rendered
          * @returns the current alpha mode
          */
         getAlphaMode(): number;
@@ -52402,6 +52842,7 @@ declare module BABYLON {
          */
         uniformScaleGizmo: AxisScaleGizmo;
         private _meshAttached;
+        private _nodeAttached;
         private _updateGizmoRotationToMatchAttachedMesh;
         private _snapDistance;
         private _scaleRatio;
@@ -52414,11 +52855,14 @@ declare module BABYLON {
         onDragEndObservable: Observable<unknown>;
         get attachedMesh(): Nullable<AbstractMesh>;
         set attachedMesh(mesh: Nullable<AbstractMesh>);
+        get attachedNode(): Nullable<Node>;
+        set attachedNode(node: Nullable<Node>);
         /**
          * Creates a ScaleGizmo
          * @param gizmoLayer The utility layer the gizmo will be added to
+         * @param thickness display gizmo axis thickness
          */
-        constructor(gizmoLayer?: UtilityLayerRenderer);
+        constructor(gizmoLayer?: UtilityLayerRenderer, thickness?: number);
         set updateGizmoRotationToMatchAttachedMesh(value: boolean);
         get updateGizmoRotationToMatchAttachedMesh(): boolean;
         /**
@@ -52481,9 +52925,10 @@ declare module BABYLON {
          * @param gizmoLayer The utility layer the gizmo will be added to
          * @param dragAxis The axis which the gizmo will be able to scale on
          * @param color The color of the gizmo
+         * @param thickness display gizmo axis thickness
          */
-        constructor(dragAxis: Vector3, color?: Color3, gizmoLayer?: UtilityLayerRenderer, parent?: Nullable<ScaleGizmo>);
-        protected _attachedMeshChanged(value: Nullable<AbstractMesh>): void;
+        constructor(dragAxis: Vector3, color?: Color3, gizmoLayer?: UtilityLayerRenderer, parent?: Nullable<ScaleGizmo>, thickness?: number);
+        protected _attachedNodeChanged(value: Nullable<Node>): void;
         /**
      * If the gizmo is enabled
      */
@@ -52561,11 +53006,11 @@ declare module BABYLON {
          */
         onRotationSphereDragEndObservable: Observable<{}>;
         /**
-         * Relative bounding box pivot used when scaling the attached mesh. When null object with scale from the opposite corner. 0.5,0.5,0.5 for center and 0.5,0,0.5 for bottom (Default: null)
+         * Relative bounding box pivot used when scaling the attached node. When null object with scale from the opposite corner. 0.5,0.5,0.5 for center and 0.5,0,0.5 for bottom (Default: null)
          */
         scalePivot: Nullable<Vector3>;
         /**
-         * Mesh used as a pivot to rotate the attached mesh
+         * Mesh used as a pivot to rotate the attached node
          */
         private _anchorMesh;
         private _existingMeshScale;
@@ -52584,7 +53029,7 @@ declare module BABYLON {
          * @param color The color of the gizmo
          */
         constructor(color?: Color3, gizmoLayer?: UtilityLayerRenderer);
-        protected _attachedMeshChanged(value: Nullable<AbstractMesh>): void;
+        protected _attachedNodeChanged(value: Nullable<AbstractMesh>): void;
         private _selectNode;
         /**
          * Updates the bounding box information for the Gizmo
@@ -52655,9 +53100,10 @@ declare module BABYLON {
          * @param color The color of the gizmo
          * @param tessellation Amount of tessellation to be used when creating rotation circles
          * @param useEulerRotation Use and update Euler angle instead of quaternion
+         * @param thickness display gizmo axis thickness
          */
-        constructor(planeNormal: Vector3, color?: Color3, gizmoLayer?: UtilityLayerRenderer, tessellation?: number, parent?: Nullable<RotationGizmo>, useEulerRotation?: boolean);
-        protected _attachedMeshChanged(value: Nullable<AbstractMesh>): void;
+        constructor(planeNormal: Vector3, color?: Color3, gizmoLayer?: UtilityLayerRenderer, tessellation?: number, parent?: Nullable<RotationGizmo>, useEulerRotation?: boolean, thickness?: number);
+        protected _attachedNodeChanged(value: Nullable<Node>): void;
         /**
              * If the gizmo is enabled
              */
@@ -52691,15 +53137,19 @@ declare module BABYLON {
         /** Fires an event when any of it's sub gizmos are released from dragging */
         onDragEndObservable: Observable<unknown>;
         private _meshAttached;
+        private _nodeAttached;
         get attachedMesh(): Nullable<AbstractMesh>;
         set attachedMesh(mesh: Nullable<AbstractMesh>);
+        get attachedNode(): Nullable<Node>;
+        set attachedNode(node: Nullable<Node>);
         /**
          * Creates a RotationGizmo
          * @param gizmoLayer The utility layer the gizmo will be added to
          * @param tessellation Amount of tessellation to be used when creating rotation circles
          * @param useEulerRotation Use and update Euler angle instead of quaternion
+         * @param thickness display gizmo axis thickness
          */
-        constructor(gizmoLayer?: UtilityLayerRenderer, tessellation?: number, useEulerRotation?: boolean);
+        constructor(gizmoLayer?: UtilityLayerRenderer, tessellation?: number, useEulerRotation?: boolean, thickness?: number);
         set updateGizmoRotationToMatchAttachedMesh(value: boolean);
         get updateGizmoRotationToMatchAttachedMesh(): boolean;
         /**
@@ -52748,6 +53198,7 @@ declare module BABYLON {
         private _boundingBoxColor;
         private _defaultUtilityLayer;
         private _defaultKeepDepthUtilityLayer;
+        private _thickness;
         /**
          * When bounding box gizmo is enabled, this can be used to track drag/end events
          */
@@ -52771,8 +53222,9 @@ declare module BABYLON {
         /**
          * Instatiates a gizmo manager
          * @param scene the scene to overlay the gizmos on top of
+         * @param thickness display gizmo axis thickness
          */
-        constructor(scene: Scene);
+        constructor(scene: Scene, thickness?: number);
         /**
          * Attaches a set of gizmos to the specified mesh
          * @param mesh The mesh the gizmo's should be attached to
@@ -54415,7 +54867,7 @@ declare module BABYLON {
         /**
          * Stores the sheen tint values in a texture.
          * rgb is tint
-         * a is a intensity
+         * a is a intensity or roughness if roughness has been defined
          */
         texture: Nullable<BaseTexture>;
         private _roughness;
@@ -54568,6 +55020,17 @@ declare module BABYLON {
         isTranslucencyEnabled: boolean;
         private _isScatteringEnabled;
         /**
+         * Defines if the sub surface scattering is enabled in the material.
+         */
+        isScatteringEnabled: boolean;
+        private _scatteringDiffusionProfileIndex;
+        /**
+         * Diffusion profile for subsurface scattering.
+         * Useful for better scattering in the skins or foliages.
+         */
+        get scatteringDiffusionProfile(): Nullable<Color3>;
+        set scatteringDiffusionProfile(c: Nullable<Color3>);
+        /**
          * Defines the refraction intensity of the material.
          * The refraction when enabled replaces the Diffuse part of the material.
          * The intensity helps transitionning between diffuse and refraction.
@@ -54579,12 +55042,6 @@ declare module BABYLON {
          * is addded to the diffuse part of the material.
          */
         translucencyIntensity: number;
-        /**
-         * Defines the scattering intensity of the material.
-         * When scattering has been enabled, this defines how much of the "scattered light"
-         * is addded to the diffuse part of the material.
-         */
-        scatteringIntensity: number;
         /**
          * When enabled, transparent surfaces will be tinted with the albedo colour (independent of thickness)
          */
@@ -54666,15 +55123,21 @@ declare module BABYLON {
          * * the alpha channel is the refraction intensity.
          */
         useMaskFromThicknessTexture: boolean;
+        private _scene;
         /** @hidden */
         private _internalMarkAllSubMeshesAsTexturesDirty;
+        private _internalMarkScenePrePassDirty;
         /** @hidden */
         _markAllSubMeshesAsTexturesDirty(): void;
+        /** @hidden */
+        _markScenePrePassDirty(): void;
         /**
          * Instantiate a new istance of sub surface configuration.
          * @param markAllSubMeshesAsTexturesDirty Callback to flag the material to dirty
+         * @param markScenePrePassDirty Callback to flag the scene as prepass dirty
+         * @param scene The scene
          */
-        constructor(markAllSubMeshesAsTexturesDirty: () => void);
+        constructor(markAllSubMeshesAsTexturesDirty: () => void, markScenePrePassDirty: () => void, scene: Scene);
         /**
          * Gets wehter the submesh is ready to be used or not.
          * @param defines the list of "defines" to update.
@@ -54963,6 +55426,13 @@ declare module BABYLON {
 }
 declare module BABYLON {
     /** @hidden */
+    export var pbrBlockLightmapInit: {
+        name: string;
+        shader: string;
+    };
+}
+declare module BABYLON {
+    /** @hidden */
     export var pbrBlockGeometryInfo: {
         name: string;
         shader: string;
@@ -55140,6 +55610,8 @@ declare module BABYLON {
         HORIZONOCCLUSION: boolean;
         INSTANCES: boolean;
         THIN_INSTANCES: boolean;
+        PREPASS: boolean;
+        SCENE_MRT_COUNT: number;
         NUM_BONE_INFLUENCERS: number;
         BonesPerMesh: number;
         BONETEXTURE: boolean;
@@ -55547,6 +56019,10 @@ declare module BABYLON {
         get realTimeFilteringQuality(): number;
         set realTimeFilteringQuality(n: number);
         /**
+         * Can this material render to several textures at once
+         */
+        get canRenderToMRT(): boolean;
+        /**
          * Force normal to face away from face.
          */
         protected _forceNormalForward: boolean;
@@ -55732,6 +56208,11 @@ declare module BABYLON {
          * @returns - Boolean specifying if a texture is used in the material.
          */
         hasTexture(texture: BaseTexture): boolean;
+        /**
+         * Sets the required values to the prepass renderer.
+         * @param prePassRenderer defines the prepass renderer to setup
+         */
+        setPrePassRenderer(prePassRenderer: PrePassRenderer): boolean;
         /**
          * Disposes the resources of the material.
          * @param forceDisposeEffect - Forces the disposal of effects.
@@ -56498,9 +56979,10 @@ declare module BABYLON {
         /**
          * This returns if the loader support the current file information.
          * @param extension defines the file extension of the file being loaded
+         * @param mimeType defines the optional mime type of the file being loaded
          * @returns true if the loader can load the specified file
          */
-        canLoad(extension: string): boolean;
+        canLoad(extension: string, mimeType?: string): boolean;
         /**
          * Uploads the cube texture data to the WebGL texture. It has already been bound.
          * @param data contains the texture data
@@ -56525,13 +57007,13 @@ declare module BABYLON {
         interface Scene {
             /**
              * Creates a default light for the scene.
-             * @see http://doc.babylonjs.com/How_To/Fast_Build#create-default-light
+             * @see https://doc.babylonjs.com/How_To/Fast_Build#create-default-light
              * @param replace has the default false, when true replaces the existing lights in the scene with a hemispheric light
              */
             createDefaultLight(replace?: boolean): void;
             /**
              * Creates a default camera for the scene.
-             * @see http://doc.babylonjs.com/How_To/Fast_Build#create-default-camera
+             * @see https://doc.babylonjs.com/How_To/Fast_Build#create-default-camera
              * @param createArcRotateCamera has the default false which creates a free camera, when true creates an arc rotate camera
              * @param replace has default false, when true replaces the active camera in the scene
              * @param attachCameraControls has default false, when true attaches camera controls to the canvas.
@@ -56539,7 +57021,7 @@ declare module BABYLON {
             createDefaultCamera(createArcRotateCamera?: boolean, replace?: boolean, attachCameraControls?: boolean): void;
             /**
              * Creates a default camera and a default light.
-             * @see http://doc.babylonjs.com/how_to/Fast_Build#create-default-camera-or-light
+             * @see https://doc.babylonjs.com/how_to/Fast_Build#create-default-camera-or-light
              * @param createArcRotateCamera has the default false which creates a free camera, when true creates an arc rotate camera
              * @param replace has the default false, when true replaces the active camera/light in the scene
              * @param attachCameraControls has the default false, when true attaches camera controls to the canvas.
@@ -56547,7 +57029,7 @@ declare module BABYLON {
             createDefaultCameraOrLight(createArcRotateCamera?: boolean, replace?: boolean, attachCameraControls?: boolean): void;
             /**
              * Creates a new sky box
-             * @see http://doc.babylonjs.com/how_to/Fast_Build#create-default-skybox
+             * @see https://doc.babylonjs.com/how_to/Fast_Build#create-default-skybox
              * @param environmentTexture defines the texture to use as environment texture
              * @param pbr has default false which requires the StandardMaterial to be used, when true PBRMaterial must be used
              * @param scale defines the overall scale of the skybox
@@ -56558,21 +57040,21 @@ declare module BABYLON {
             createDefaultSkybox(environmentTexture?: BaseTexture, pbr?: boolean, scale?: number, blur?: number, setGlobalEnvTexture?: boolean): Nullable<Mesh>;
             /**
              * Creates a new environment
-             * @see http://doc.babylonjs.com/How_To/Fast_Build#create-default-environment
+             * @see https://doc.babylonjs.com/How_To/Fast_Build#create-default-environment
              * @param options defines the options you can use to configure the environment
              * @returns the new EnvironmentHelper
              */
             createDefaultEnvironment(options?: Partial<IEnvironmentHelperOptions>): Nullable<EnvironmentHelper>;
             /**
              * Creates a new VREXperienceHelper
-             * @see http://doc.babylonjs.com/how_to/webvr_helper
+             * @see https://doc.babylonjs.com/how_to/webvr_helper
              * @param webVROptions defines the options used to create the new VREXperienceHelper
              * @returns a new VREXperienceHelper
              */
             createDefaultVRExperience(webVROptions?: VRExperienceHelperOptions): VRExperienceHelper;
             /**
              * Creates a new WebXRDefaultExperience
-             * @see http://doc.babylonjs.com/how_to/webxr
+             * @see https://doc.babylonjs.com/how_to/introduction_to_webxr
              * @param options experience options
              * @returns a promise for a new WebXRDefaultExperience
              */
@@ -56614,9 +57096,13 @@ declare module BABYLON {
          */
         protected _material: BackgroundMaterial;
         /**
-         * The surface used for the skybox
+         * The surface used for the video dome
          */
         protected _mesh: Mesh;
+        /**
+         * Gets the mesh used for the video dome.
+         */
+        get mesh(): Mesh;
         /**
          * A mesh that will be used to mask the back of the video dome in case it is a 180 degree movie.
          */
@@ -56678,7 +57164,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * This class can be used to get instrumentation data from a Babylon engine
-     * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#engineinstrumentation
+     * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#engineinstrumentation
      */
     export class EngineInstrumentation implements IDisposable {
         /**
@@ -56721,7 +57207,7 @@ declare module BABYLON {
         /**
          * Instantiates a new engine instrumentation.
          * This class can be used to get instrumentation data from a Babylon engine
-         * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#engineinstrumentation
+         * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#engineinstrumentation
          * @param engine Defines the engine to instrument
          */
         constructor(
@@ -56738,7 +57224,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * This class can be used to get instrumentation data from a Babylon engine
-     * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#sceneinstrumentation
+     * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#sceneinstrumentation
      */
     export class SceneInstrumentation implements IDisposable {
         /**
@@ -56909,7 +57395,7 @@ declare module BABYLON {
         /**
          * Instantiates a new scene instrumentation.
          * This class can be used to get instrumentation data from a Babylon engine
-         * @see http://doc.babylonjs.com/how_to/optimizing_your_scene#sceneinstrumentation
+         * @see https://doc.babylonjs.com/how_to/optimizing_your_scene#sceneinstrumentation
          * @param scene Defines the scene to instrument
          */
         constructor(
@@ -57208,8 +57694,8 @@ declare module BABYLON {
         interface AbstractScene {
             /**
              * The list of effect layers (highlights/glow) added to the scene
-             * @see http://doc.babylonjs.com/how_to/highlight_layer
-             * @see http://doc.babylonjs.com/how_to/glow_layer
+             * @see https://doc.babylonjs.com/how_to/highlight_layer
+             * @see https://doc.babylonjs.com/how_to/glow_layer
              */
             effectLayers: Array<EffectLayer>;
             /**
@@ -57990,7 +58476,7 @@ declare module BABYLON {
     /**
      * This represents a Lens Flare System or the shiny effect created by the light reflection on the  camera lenses.
      * It is usually composed of several `lensFlare`.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_lens_flares
+     * @see https://doc.babylonjs.com/how_to/how_to_use_lens_flares
      */
     export class LensFlareSystem {
         /**
@@ -58036,7 +58522,7 @@ declare module BABYLON {
          * Instantiates a lens flare system.
          * This represents a Lens Flare System or the shiny effect created by the light reflection on the  camera lenses.
          * It is usually composed of several `lensFlare`.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_lens_flares
+         * @see https://doc.babylonjs.com/how_to/how_to_use_lens_flares
          * @param name Define the name of the lens flare system in the scene
          * @param emitter Define the source (the emitter) of the lens flares (it can be a camera, a light or a mesh).
          * @param scene Define the scene the lens flare system belongs to
@@ -58107,7 +58593,7 @@ declare module BABYLON {
     /**
      * This represents one of the lens effect in a `lensFlareSystem`.
      * It controls one of the indiviual texture used in the effect.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_lens_flares
+     * @see https://doc.babylonjs.com/how_to/how_to_use_lens_flares
      */
     export class LensFlare {
         /**
@@ -58135,7 +58621,7 @@ declare module BABYLON {
          * Creates a new Lens Flare.
          * This represents one of the lens effect in a `lensFlareSystem`.
          * It controls one of the indiviual texture used in the effect.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_lens_flares
+         * @see https://doc.babylonjs.com/how_to/how_to_use_lens_flares
          * @param size Define the size of the lens flare (a floating value between 0 and 1)
          * @param position Define the position of the lens flare in the system. (a floating value between -1 and 1). A value of 0 is located on the emitter. A value greater than 0 is beyond the emitter and a value lesser than 0 is behind.
          * @param color Define the lens color
@@ -58148,7 +58634,7 @@ declare module BABYLON {
          * Instantiates a new Lens Flare.
          * This represents one of the lens effect in a `lensFlareSystem`.
          * It controls one of the indiviual texture used in the effect.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_lens_flares
+         * @see https://doc.babylonjs.com/how_to/how_to_use_lens_flares
          * @param size Define the size of the lens flare in the system (a floating value between 0 and 1)
          * @param position Define the position of the lens flare in the system. (a floating value between -1 and 1). A value of 0 is located on the emitter. A value greater than 0 is beyond the emitter and a value lesser than 0 is behind.
          * @param color Define the lens color
@@ -58174,7 +58660,7 @@ declare module BABYLON {
         interface AbstractScene {
             /**
              * The list of lens flare system added to the scene
-             * @see http://doc.babylonjs.com/how_to/how_to_use_lens_flares
+             * @see https://doc.babylonjs.com/how_to/how_to_use_lens_flares
              */
             lensFlareSystems: Array<LensFlareSystem>;
             /**
@@ -58910,6 +59396,7 @@ declare module BABYLON {
          */
         static RGBE_ReadPixels(uint8array: Uint8Array, hdrInfo: HDRInfo): Float32Array;
         private static RGBE_ReadPixels_RLE;
+        private static RGBE_ReadPixels_NOT_RLE;
     }
 }
 declare module BABYLON {
@@ -59224,7 +59711,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to control physics engine
-     * @see http://doc.babylonjs.com/how_to/using_the_physics_engine
+     * @see https://doc.babylonjs.com/how_to/using_the_physics_engine
      */
     export class PhysicsEngine implements IPhysicsEngine {
         private _physicsPlugin;
@@ -59980,7 +60467,7 @@ declare module BABYLON {
         interface AbstractScene {
             /**
              * The list of reflection probes added to the scene
-             * @see http://doc.babylonjs.com/how_to/how_to_use_reflection_probes
+             * @see https://doc.babylonjs.com/how_to/how_to_use_reflection_probes
              */
             reflectionProbes: Array<ReflectionProbe>;
             /**
@@ -59997,7 +60484,7 @@ declare module BABYLON {
         }
     /**
      * Class used to generate realtime reflection / refraction cube textures
-     * @see http://doc.babylonjs.com/how_to/how_to_use_reflection_probes
+     * @see https://doc.babylonjs.com/how_to/how_to_use_reflection_probes
      */
     export class ReflectionProbe {
         /** defines the name of the probe */
@@ -60931,7 +61418,7 @@ declare module BABYLON {
     /**
      * Procedural texturing is a way to programmatically create a texture. There are 2 types of procedural textures: code-only, and code that references some classic 2D images, sometimes called 'refMaps' or 'sampler' images.
      * Custom Procedural textures are the easiest way to create your own procedural in your application.
-     * @see http://doc.babylonjs.com/how_to/how_to_use_procedural_textures#creating-custom-procedural-textures
+     * @see https://doc.babylonjs.com/how_to/how_to_use_procedural_textures#creating-custom-procedural-textures
      */
     export class CustomProceduralTexture extends ProceduralTexture {
         private _animate;
@@ -60942,7 +61429,7 @@ declare module BABYLON {
          * Instantiates a new Custom Procedural Texture.
          * Procedural texturing is a way to programmatically create a texture. There are 2 types of procedural textures: code-only, and code that references some classic 2D images, sometimes called 'refMaps' or 'sampler' images.
          * Custom Procedural textures are the easiest way to create your own procedural in your application.
-         * @see http://doc.babylonjs.com/how_to/how_to_use_procedural_textures#creating-custom-procedural-textures
+         * @see https://doc.babylonjs.com/how_to/how_to_use_procedural_textures#creating-custom-procedural-textures
          * @param name Define the name of the texture
          * @param texturePath Define the folder path containing all the cutom texture related files (config, shaders...)
          * @param size Define the size of the texture to create
@@ -65354,7 +65841,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * A simplifier interface for future simplification implementations
-     * @see http://doc.babylonjs.com/how_to/in-browser_mesh_simplification
+     * @see https://doc.babylonjs.com/how_to/in-browser_mesh_simplification
      */
     export interface ISimplifier {
         /**
@@ -65369,7 +65856,7 @@ declare module BABYLON {
     /**
      * Expected simplification settings.
      * Quality should be between 0 and 1 (1 being 100%, 0 being 0%)
-     * @see http://doc.babylonjs.com/how_to/in-browser_mesh_simplification
+     * @see https://doc.babylonjs.com/how_to/in-browser_mesh_simplification
      */
     export interface ISimplificationSettings {
         /**
@@ -65387,7 +65874,7 @@ declare module BABYLON {
     }
     /**
      * Class used to specify simplification options
-     * @see http://doc.babylonjs.com/how_to/in-browser_mesh_simplification
+     * @see https://doc.babylonjs.com/how_to/in-browser_mesh_simplification
      */
     export class SimplificationSettings implements ISimplificationSettings {
         /** expected quality */
@@ -65437,7 +65924,7 @@ declare module BABYLON {
     }
     /**
      * Queue used to order the simplification tasks
-     * @see http://doc.babylonjs.com/how_to/in-browser_mesh_simplification
+     * @see https://doc.babylonjs.com/how_to/in-browser_mesh_simplification
      */
     export class SimplificationQueue {
         private _simplificationArray;
@@ -65468,7 +65955,7 @@ declare module BABYLON {
     /**
      * The implemented types of simplification
      * At the moment only Quadratic Error Decimation is implemented
-     * @see http://doc.babylonjs.com/how_to/in-browser_mesh_simplification
+     * @see https://doc.babylonjs.com/how_to/in-browser_mesh_simplification
      */
     export enum SimplificationType {
         /** Quadratic error decimation */
@@ -65479,7 +65966,7 @@ declare module BABYLON {
      * Original paper : http://www1.cs.columbia.edu/~cs4162/html05s/garland97.pdf
      * Ported mostly from QSlim and http://voxels.blogspot.de/2014/05/quadric-mesh-simplification-with-source.html to babylon JS
      * @author RaananW
-     * @see http://doc.babylonjs.com/how_to/in-browser_mesh_simplification
+     * @see https://doc.babylonjs.com/how_to/in-browser_mesh_simplification
      */
     export class QuadraticErrorSimplification implements ISimplifier {
         private _mesh;
@@ -65526,7 +66013,7 @@ declare module BABYLON {
             _simplificationQueue: SimplificationQueue;
             /**
              * Gets or sets the simplification queue attached to the scene
-             * @see http://doc.babylonjs.com/how_to/in-browser_mesh_simplification
+             * @see https://doc.babylonjs.com/how_to/in-browser_mesh_simplification
              */
             simplificationQueue: SimplificationQueue;
         }
@@ -66213,7 +66700,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to enable access to IndexedDB
-     * @see http://doc.babylonjs.com/how_to/caching_resources_in_indexeddb
+     * @see https://doc.babylonjs.com/how_to/caching_resources_in_indexeddb
      */
     export class Database implements IOfflineProvider {
         private _callbackManifestChecked;
@@ -66628,7 +67115,7 @@ declare module BABYLON {
         /**
          * Not supported by GPUParticleSystem
          * Gets or sets a boolean indicating that ramp gradients must be used
-         * @see http://doc.babylonjs.com/babylon101/particles#ramp-gradients
+         * @see https://doc.babylonjs.com/babylon101/particles#ramp-gradients
          */
         get useRampGradients(): boolean;
         set useRampGradients(value: boolean);
@@ -67338,12 +67825,12 @@ declare module BABYLON {
             _physicsImpostor: Nullable<PhysicsImpostor>;
             /**
              * Gets or sets impostor used for physic simulation
-             * @see http://doc.babylonjs.com/features/physics_engine
+             * @see https://doc.babylonjs.com/features/physics_engine
              */
             physicsImpostor: Nullable<PhysicsImpostor>;
             /**
              * Gets the current physics impostor
-             * @see http://doc.babylonjs.com/features/physics_engine
+             * @see https://doc.babylonjs.com/features/physics_engine
              * @returns a physics impostor or null
              */
             getPhysicsImpostor(): Nullable<PhysicsImpostor>;
@@ -67351,7 +67838,7 @@ declare module BABYLON {
              * @param force defines the force to apply
              * @param contactPoint defines where to apply the force
              * @returns the current mesh
-             * @see http://doc.babylonjs.com/how_to/using_the_physics_engine
+             * @see https://doc.babylonjs.com/how_to/using_the_physics_engine
              */
             applyImpulse(force: Vector3, contactPoint: Vector3): AbstractMesh;
             /**
@@ -68610,6 +69097,7 @@ declare module BABYLON {
         /** Gets or sets a boolean indicating if transparent meshes should be rendered */
         renderTransparentMeshes: boolean;
         private _scene;
+        private _resizeObserver;
         private _multiRenderTarget;
         private _ratio;
         private _enablePosition;
@@ -68984,6 +69472,12 @@ declare module BABYLON {
         _reset(): void;
         protected _enableMSAAOnFirstPostProcess(sampleCount: number): boolean;
         /**
+         * Sets the required values to the prepass renderer.
+         * @param prePassRenderer defines the prepass renderer to setup.
+         * @returns true if the pre pass is needed.
+         */
+        setPrePassRenderer(prePassRenderer: PrePassRenderer): boolean;
+        /**
          * Disposes of the pipeline
          */
         dispose(): void;
@@ -69055,8 +69549,8 @@ declare module BABYLON {
             _postProcessRenderPipelineManager: PostProcessRenderPipelineManager;
             /**
              * Gets the postprocess render pipeline manager
-             * @see http://doc.babylonjs.com/how_to/how_to_use_postprocessrenderpipeline
-             * @see http://doc.babylonjs.com/how_to/using_default_rendering_pipeline
+             * @see https://doc.babylonjs.com/how_to/how_to_use_postprocessrenderpipeline
+             * @see https://doc.babylonjs.com/how_to/using_default_rendering_pipeline
              */
             readonly postProcessRenderPipelineManager: PostProcessRenderPipelineManager;
         }
@@ -69628,6 +70122,10 @@ declare module BABYLON {
         set textureSamples(n: number);
         get textureSamples(): number;
         /**
+         * Force rendering the geometry through geometry buffer
+         */
+        private _forceGeometryBuffer;
+        /**
          * Ratio object used for SSAO ratio and blur ratio
          */
         private _ratio;
@@ -69659,14 +70157,13 @@ declare module BABYLON {
         */
         static get IsSupported(): boolean;
         private _scene;
-        private _depthTexture;
-        private _normalTexture;
         private _randomTexture;
         private _originalColorPostProcess;
         private _ssaoPostProcess;
         private _blurHPostProcess;
         private _blurVPostProcess;
         private _ssaoCombinePostProcess;
+        private _prePassRenderer;
         /**
          * Gets active scene
          */
@@ -69677,8 +70174,9 @@ declare module BABYLON {
          * @param scene The scene linked to this pipeline
          * @param ratio The size of the postprocesses. Can be a number shared between passes or an object for more precision: { ssaoRatio: 0.5, blurRatio: 1.0 }
          * @param cameras The array of cameras that the rendering pipeline will be attached to
+         * @param forceGeometryBuffer Set to true if you want to use the legacy geometry buffer renderer
          */
-        constructor(name: string, scene: Scene, ratio: any, cameras?: Camera[]);
+        constructor(name: string, scene: Scene, ratio: any, cameras?: Camera[], forceGeometryBuffer?: boolean);
         /**
          * Get the class name
          * @returns "SSAO2RenderingPipeline"
@@ -69696,6 +70194,7 @@ declare module BABYLON {
         private _hammersley;
         private _hemisphereSample_uniform;
         private _generateHemisphere;
+        private _getDefinesForSSAO;
         private _createSSAOPostProcess;
         private _createSSAOCombinePostProcess;
         private _createRandomTexture;
@@ -69712,6 +70211,12 @@ declare module BABYLON {
          * @returns An instantiated pipeline from the serialized object.
          */
         static Parse(source: any, scene: Scene, rootUrl: string): SSAO2RenderingPipeline;
+        /**
+         * Sets the required values to the prepass renderer.
+         * @param prePassRenderer defines the prepass renderer to setup
+         * @returns true if the pre pass is needed.
+         */
+        setPrePassRenderer(prePassRenderer: PrePassRenderer): boolean;
     }
 }
 declare module BABYLON {
@@ -70480,6 +70985,46 @@ declare module BABYLON {
     }
 }
 declare module BABYLON {
+    /** @hidden */
+    export var screenSpaceCurvaturePixelShader: {
+        name: string;
+        shader: string;
+    };
+}
+declare module BABYLON {
+    /**
+     * The Screen Space curvature effect can help highlighting ridge and valley of a model.
+     */
+    export class ScreenSpaceCurvaturePostProcess extends PostProcess {
+        /**
+         * Defines how much ridge the curvature effect displays.
+         */
+        ridge: number;
+        /**
+         * Defines how much valley the curvature effect displays.
+         */
+        valley: number;
+        private _geometryBufferRenderer;
+        /**
+         * Creates a new instance ScreenSpaceCurvaturePostProcess
+         * @param name The name of the effect.
+         * @param scene The scene containing the objects to blur according to their velocity.
+         * @param options The required width/height ratio to downsize to before computing the render pass.
+         * @param camera The camera to apply the render pass to.
+         * @param samplingMode The sampling mode to be used when computing the pass. (default: 0)
+         * @param engine The engine which the post process will be applied. (default: current engine)
+         * @param reusable If the post process can be reused on the same frame. (default: false)
+         * @param textureType Type of textures used when performing the post process. (default: 0)
+         * @param blockCompilation If compilation of the shader should not be done in the constructor. The updateEffect method can be used to compile the shader at a later time. (default: false)
+         */
+        constructor(name: string, scene: Scene, options: number | PostProcessOptions, camera: Nullable<Camera>, samplingMode?: number, engine?: Engine, reusable?: boolean, textureType?: number, blockCompilation?: boolean);
+        /**
+         * Support test.
+         */
+        static get IsSupported(): boolean;
+    }
+}
+declare module BABYLON {
         interface Scene {
             /** @hidden (Backing field) */
             _boundingBoxRenderer: BoundingBoxRenderer;
@@ -70635,6 +71180,76 @@ declare module BABYLON {
         dispose(): void;
         private _gatherRenderTargets;
         private _gatherActiveCameraRenderTargets;
+    }
+}
+declare module BABYLON {
+        interface AbstractScene {
+            /** @hidden (Backing field) */
+            _prePassRenderer: Nullable<PrePassRenderer>;
+            /**
+             * Gets or Sets the current prepass renderer associated to the scene.
+             */
+            prePassRenderer: Nullable<PrePassRenderer>;
+            /**
+             * Enables the prepass and associates it with the scene
+             * @returns the PrePassRenderer
+             */
+            enablePrePassRenderer(): Nullable<PrePassRenderer>;
+            /**
+             * Disables the prepass associated with the scene
+             */
+            disablePrePassRenderer(): void;
+        }
+    /**
+     * Defines the Geometry Buffer scene component responsible to manage a G-Buffer useful
+     * in several rendering techniques.
+     */
+    export class PrePassRendererSceneComponent implements ISceneSerializableComponent {
+        /**
+         * The component name helpful to identify the component in the list of scene components.
+         */
+        readonly name: string;
+        /**
+         * The scene the component belongs to.
+         */
+        scene: Scene;
+        /**
+         * Creates a new instance of the component for the given scene
+         * @param scene Defines the scene to register the component in
+         */
+        constructor(scene: Scene);
+        /**
+         * Registers the component in a given scene
+         */
+        register(): void;
+        private _beforeCameraDraw;
+        private _afterCameraDraw;
+        private _beforeClearStage;
+        /**
+         * Serializes the component data to the specified json object
+         * @param serializationObject The object to serialize to
+         */
+        serialize(serializationObject: any): void;
+        /**
+         * Adds all the elements from the container to the scene
+         * @param container the container holding the elements
+         */
+        addFromContainer(container: AbstractScene): void;
+        /**
+         * Removes all the elements in the container from the scene
+         * @param container contains the elements to remove
+         * @param dispose if the removed element should be disposed (default: false)
+         */
+        removeFromContainer(container: AbstractScene, dispose?: boolean): void;
+        /**
+         * Rebuilds the elements related to this component in case of
+         * context lost for instance.
+         */
+        rebuild(): void;
+        /**
+         * Disposes the component and the associated ressources
+         */
+        dispose(): void;
     }
 }
 declare module BABYLON {
@@ -71015,7 +71630,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Class used to manage multiple sprites of different sizes on the same spritesheet
-     * @see http://doc.babylonjs.com/babylon101/sprites
+     * @see https://doc.babylonjs.com/babylon101/sprites
      */
     export class SpritePackedManager extends SpriteManager {
         /** defines the packed manager's name */
@@ -71707,7 +72322,7 @@ declare module BABYLON {
     }
     /**
      * This class can be used to easily import assets into a scene
-     * @see http://doc.babylonjs.com/how_to/how_to_use_assetsmanager
+     * @see https://doc.babylonjs.com/how_to/how_to_use_assetsmanager
      */
     export class AssetsManager {
         private _scene;
@@ -71749,7 +72364,7 @@ declare module BABYLON {
         onProgressObservable: Observable<IAssetsProgressEvent>;
         /**
          * Gets or sets a boolean defining if the AssetsManager should use the default loading screen
-         * @see http://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
+         * @see https://doc.babylonjs.com/how_to/creating_a_custom_loading_screen
          */
         useDefaultLoadingScreen: boolean;
         /**
@@ -71937,7 +72552,7 @@ declare module BABYLON {
         /**
          * Callback called when a file is processed
          */
-        onProcessFileCallback: (file: File, name: string, extension: string) => true;
+        onProcessFileCallback: (file: File, name: string, extension: string) => boolean;
         private _engine;
         private _currentScene;
         private _sceneLoadedCallback;
@@ -71962,7 +72577,7 @@ declare module BABYLON {
          * @param onReloadCallback callback called when a reload is requested
          * @param errorCallback callback call if an error occurs
          */
-        constructor(engine: Engine, scene: Scene, sceneLoadedCallback: (sceneFile: File, scene: Scene) => void, progressCallback: (progress: ISceneLoaderProgressEvent) => void, additionalRenderLoopLogicCallback: () => void, textureLoadingCallback: (remaining: number) => void, startingProcessingFilesCallback: (files?: File[]) => void, onReloadCallback: (sceneFile: File) => void, errorCallback: (sceneFile: File, scene: Scene, message: string) => void);
+        constructor(engine: Engine, scene: Nullable<Scene>, sceneLoadedCallback: Nullable<(sceneFile: File, scene: Scene) => void>, progressCallback: Nullable<(progress: ISceneLoaderProgressEvent) => void>, additionalRenderLoopLogicCallback: Nullable<() => void>, textureLoadingCallback: Nullable<(remaining: number) => void>, startingProcessingFilesCallback: Nullable<(files?: File[]) => void>, onReloadCallback: Nullable<(sceneFile: File) => void>, errorCallback: Nullable<(sceneFile: File, scene: Nullable<Scene>, message: string) => void>);
         private _dragEnterHandler;
         private _dragOverHandler;
         private _dropHandler;
@@ -71971,6 +72586,8 @@ declare module BABYLON {
          * @param elementToMonitor defines the DOM element to track
          */
         monitorElementForDragNDrop(elementToMonitor: HTMLElement): void;
+        /** Gets the current list of files to load */
+        get filesToLoad(): File[];
         /**
          * Release all associated resources
          */
@@ -71995,7 +72612,7 @@ declare module BABYLON {
 declare module BABYLON {
     /**
      * Defines the root class used to create scene optimization to use with SceneOptimizer
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class SceneOptimization {
         /**
@@ -72027,7 +72644,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization used to reduce the size of render target textures
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class TextureOptimization extends SceneOptimization {
         /**
@@ -72076,7 +72693,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization used to increase or decrease the rendering resolution
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class HardwareScalingOptimization extends SceneOptimization {
         /**
@@ -72127,7 +72744,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization used to remove shadows
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class ShadowsOptimization extends SceneOptimization {
         /**
@@ -72145,7 +72762,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization used to turn post-processes off
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class PostProcessesOptimization extends SceneOptimization {
         /**
@@ -72163,7 +72780,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization used to turn lens flares off
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class LensFlaresOptimization extends SceneOptimization {
         /**
@@ -72181,7 +72798,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization based on user defined callback.
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class CustomOptimization extends SceneOptimization {
         /**
@@ -72207,7 +72824,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization used to turn particles off
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class ParticlesOptimization extends SceneOptimization {
         /**
@@ -72225,7 +72842,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization used to turn render targets off
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class RenderTargetsOptimization extends SceneOptimization {
         /**
@@ -72243,7 +72860,7 @@ declare module BABYLON {
     }
     /**
      * Defines an optimization used to merge meshes with compatible materials
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class MergeMeshesOptimization extends SceneOptimization {
         private static _UpdateSelectionTree;
@@ -72272,7 +72889,7 @@ declare module BABYLON {
     }
     /**
      * Defines a list of options used by SceneOptimizer
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class SceneOptimizerOptions {
         /**
@@ -72336,7 +72953,7 @@ declare module BABYLON {
     }
     /**
      * Class used to run optimizations in order to reach a target frame rate
-     * @description More details at http://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
+     * @description More details at https://doc.babylonjs.com/how_to/how_to_use_sceneoptimizer
      */
     export class SceneOptimizer implements IDisposable {
         private _isRunning;
@@ -72488,7 +73105,7 @@ declare module BABYLON {
      * This can help with recording videos from BabylonJS.
      * This is based on the available WebRTC functionalities of the browser.
      *
-     * @see http://doc.babylonjs.com/how_to/render_scene_on_a_video
+     * @see https://doc.babylonjs.com/how_to/render_scene_on_a_video
      */
     export class VideoRecorder {
         private static readonly _defaultOptions;
@@ -72544,7 +73161,7 @@ declare module BABYLON {
     export class ScreenshotTools {
         /**
          * Captures a screenshot of the current rendering
-         * @see http://doc.babylonjs.com/how_to/render_scene_on_a_png
+         * @see https://doc.babylonjs.com/how_to/render_scene_on_a_png
          * @param engine defines the rendering engine
          * @param camera defines the source camera
          * @param size This parameter can be set to a single number or to an object with the
@@ -72561,7 +73178,7 @@ declare module BABYLON {
         static CreateScreenshot(engine: Engine, camera: Camera, size: IScreenshotSize | number, successCallback?: (data: string) => void, mimeType?: string): void;
         /**
          * Captures a screenshot of the current rendering
-         * @see http://doc.babylonjs.com/how_to/render_scene_on_a_png
+         * @see https://doc.babylonjs.com/how_to/render_scene_on_a_png
          * @param engine defines the rendering engine
          * @param camera defines the source camera
          * @param size This parameter can be set to a single number or to an object with the
@@ -72577,7 +73194,7 @@ declare module BABYLON {
         static CreateScreenshotAsync(engine: Engine, camera: Camera, size: any, mimeType?: string): Promise<string>;
         /**
          * Generates an image screenshot from the specified camera.
-         * @see http://doc.babylonjs.com/how_to/render_scene_on_a_png
+         * @see https://doc.babylonjs.com/how_to/render_scene_on_a_png
          * @param engine The engine to use for rendering
          * @param camera The camera to use for rendering
          * @param size This parameter can be set to a single number or to an object with the
@@ -72598,7 +73215,7 @@ declare module BABYLON {
         static CreateScreenshotUsingRenderTarget(engine: Engine, camera: Camera, size: IScreenshotSize | number, successCallback?: (data: string) => void, mimeType?: string, samples?: number, antialiasing?: boolean, fileName?: string, renderSprites?: boolean): void;
         /**
          * Generates an image screenshot from the specified camera.
-         * @see http://doc.babylonjs.com/how_to/render_scene_on_a_png
+         * @see https://doc.babylonjs.com/how_to/render_scene_on_a_png
          * @param engine The engine to use for rendering
          * @param camera The camera to use for rendering
          * @param size This parameter can be set to a single number or to an object with the
@@ -74435,7 +75052,7 @@ declare module BABYLON.GUI {
         private _originalUnit;
         /**
          * Gets or sets a value indicating that this value will not scale accordingly with adaptive scaling property
-         * @see http://doc.babylonjs.com/how_to/gui#adaptive-scaling
+         * @see https://doc.babylonjs.com/how_to/gui#adaptive-scaling
          */
         ignoreAdaptiveScaling: boolean;
         /**
@@ -74747,7 +75364,7 @@ declare module BABYLON.GUI {
     }
     /**
     * Class used to create texture to support 2D GUI elements
-    * @see http://doc.babylonjs.com/how_to/gui
+    * @see https://doc.babylonjs.com/how_to/gui
     */
     export class AdvancedDynamicTexture extends BABYLON.DynamicTexture {
         private _isDirty;
@@ -74845,32 +75462,32 @@ declare module BABYLON.GUI {
         /**
         * Gets or sets the ideal width used to design controls.
         * The GUI will then rescale everything accordingly
-        * @see http://doc.babylonjs.com/how_to/gui#adaptive-scaling
+        * @see https://doc.babylonjs.com/how_to/gui#adaptive-scaling
         */
         get idealWidth(): number;
         set idealWidth(value: number);
         /**
         * Gets or sets the ideal height used to design controls.
         * The GUI will then rescale everything accordingly
-        * @see http://doc.babylonjs.com/how_to/gui#adaptive-scaling
+        * @see https://doc.babylonjs.com/how_to/gui#adaptive-scaling
         */
         get idealHeight(): number;
         set idealHeight(value: number);
         /**
         * Gets or sets a boolean indicating if the smallest ideal value must be used if idealWidth and idealHeight are both set
-        * @see http://doc.babylonjs.com/how_to/gui#adaptive-scaling
+        * @see https://doc.babylonjs.com/how_to/gui#adaptive-scaling
         */
         get useSmallestIdeal(): boolean;
         set useSmallestIdeal(value: boolean);
         /**
         * Gets or sets a boolean indicating if adaptive scaling must be used
-        * @see http://doc.babylonjs.com/how_to/gui#adaptive-scaling
+        * @see https://doc.babylonjs.com/how_to/gui#adaptive-scaling
         */
         get renderAtIdealSize(): boolean;
         set renderAtIdealSize(value: boolean);
         /**
          * Gets the ratio used when in "ideal mode"
-        * @see http://doc.babylonjs.com/how_to/gui#adaptive-scaling
+        * @see https://doc.babylonjs.com/how_to/gui#adaptive-scaling
          * */
         get idealRatio(): number;
         /**
@@ -74952,7 +75569,7 @@ declare module BABYLON.GUI {
         /**
         * Helper function used to create a new style
         * @returns a new style
-        * @see http://doc.babylonjs.com/how_to/gui#styles
+        * @see https://doc.babylonjs.com/how_to/gui#styles
         */
         createStyle(): Style;
         /**
@@ -75052,7 +75669,7 @@ declare module BABYLON.GUI {
 declare module BABYLON.GUI {
     /**
      * Root class used for all 2D controls
-     * @see http://doc.babylonjs.com/how_to/gui#controls
+     * @see https://doc.babylonjs.com/how_to/gui#controls
      */
     export class Control {
         /** defines the name of the control */
@@ -75273,63 +75890,63 @@ declare module BABYLON.GUI {
         get isHighlighted(): boolean;
         set isHighlighted(value: boolean);
         /** Gets or sets a value indicating the scale factor on X axis (1 by default)
-         * @see http://doc.babylonjs.com/how_to/gui#rotation-and-scaling
+         * @see https://doc.babylonjs.com/how_to/gui#rotation-and-scaling
         */
         get scaleX(): number;
         set scaleX(value: number);
         /** Gets or sets a value indicating the scale factor on Y axis (1 by default)
-         * @see http://doc.babylonjs.com/how_to/gui#rotation-and-scaling
+         * @see https://doc.babylonjs.com/how_to/gui#rotation-and-scaling
         */
         get scaleY(): number;
         set scaleY(value: number);
         /** Gets or sets the rotation angle (0 by default)
-         * @see http://doc.babylonjs.com/how_to/gui#rotation-and-scaling
+         * @see https://doc.babylonjs.com/how_to/gui#rotation-and-scaling
         */
         get rotation(): number;
         set rotation(value: number);
         /** Gets or sets the transformation center on Y axis (0 by default)
-         * @see http://doc.babylonjs.com/how_to/gui#rotation-and-scaling
+         * @see https://doc.babylonjs.com/how_to/gui#rotation-and-scaling
         */
         get transformCenterY(): number;
         set transformCenterY(value: number);
         /** Gets or sets the transformation center on X axis (0 by default)
-         * @see http://doc.babylonjs.com/how_to/gui#rotation-and-scaling
+         * @see https://doc.babylonjs.com/how_to/gui#rotation-and-scaling
         */
         get transformCenterX(): number;
         set transformCenterX(value: number);
         /**
          * Gets or sets the horizontal alignment
-         * @see http://doc.babylonjs.com/how_to/gui#alignments
+         * @see https://doc.babylonjs.com/how_to/gui#alignments
          */
         get horizontalAlignment(): number;
         set horizontalAlignment(value: number);
         /**
          * Gets or sets the vertical alignment
-         * @see http://doc.babylonjs.com/how_to/gui#alignments
+         * @see https://doc.babylonjs.com/how_to/gui#alignments
          */
         get verticalAlignment(): number;
         set verticalAlignment(value: number);
         /**
          * Gets or sets control width
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get width(): string | number;
         set width(value: string | number);
         /**
          * Gets or sets the control width in pixel
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get widthInPixels(): number;
         set widthInPixels(value: number);
         /**
          * Gets or sets control height
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get height(): string | number;
         set height(value: string | number);
         /**
          * Gets or sets control height in pixel
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get heightInPixels(): number;
         set heightInPixels(value: number);
@@ -75344,7 +75961,7 @@ declare module BABYLON.GUI {
         set fontWeight(value: string);
         /**
          * Gets or sets style
-         * @see http://doc.babylonjs.com/how_to/gui#styles
+         * @see https://doc.babylonjs.com/how_to/gui#styles
          */
         get style(): BABYLON.Nullable<Style>;
         set style(value: BABYLON.Nullable<Style>);
@@ -75376,97 +75993,97 @@ declare module BABYLON.GUI {
         get linkedMesh(): BABYLON.Nullable<BABYLON.AbstractMesh>;
         /**
          * Gets or sets a value indicating the padding to use on the left of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get paddingLeft(): string | number;
         set paddingLeft(value: string | number);
         /**
          * Gets or sets a value indicating the padding in pixels to use on the left of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get paddingLeftInPixels(): number;
         set paddingLeftInPixels(value: number);
         /**
          * Gets or sets a value indicating the padding to use on the right of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get paddingRight(): string | number;
         set paddingRight(value: string | number);
         /**
          * Gets or sets a value indicating the padding in pixels to use on the right of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get paddingRightInPixels(): number;
         set paddingRightInPixels(value: number);
         /**
          * Gets or sets a value indicating the padding to use on the top of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get paddingTop(): string | number;
         set paddingTop(value: string | number);
         /**
          * Gets or sets a value indicating the padding in pixels to use on the top of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get paddingTopInPixels(): number;
         set paddingTopInPixels(value: number);
         /**
          * Gets or sets a value indicating the padding to use on the bottom of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get paddingBottom(): string | number;
         set paddingBottom(value: string | number);
         /**
          * Gets or sets a value indicating the padding in pixels to use on the bottom of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get paddingBottomInPixels(): number;
         set paddingBottomInPixels(value: number);
         /**
          * Gets or sets a value indicating the left coordinate of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get left(): string | number;
         set left(value: string | number);
         /**
          * Gets or sets a value indicating the left coordinate in pixels of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get leftInPixels(): number;
         set leftInPixels(value: number);
         /**
          * Gets or sets a value indicating the top coordinate of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get top(): string | number;
         set top(value: string | number);
         /**
          * Gets or sets a value indicating the top coordinate in pixels of the control
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get topInPixels(): number;
         set topInPixels(value: number);
         /**
          * Gets or sets a value indicating the offset on X axis to the linked mesh
-         * @see http://doc.babylonjs.com/how_to/gui#tracking-positions
+         * @see https://doc.babylonjs.com/how_to/gui#tracking-positions
          */
         get linkOffsetX(): string | number;
         set linkOffsetX(value: string | number);
         /**
          * Gets or sets a value indicating the offset in pixels on X axis to the linked mesh
-         * @see http://doc.babylonjs.com/how_to/gui#tracking-positions
+         * @see https://doc.babylonjs.com/how_to/gui#tracking-positions
          */
         get linkOffsetXInPixels(): number;
         set linkOffsetXInPixels(value: number);
         /**
          * Gets or sets a value indicating the offset on Y axis to the linked mesh
-         * @see http://doc.babylonjs.com/how_to/gui#tracking-positions
+         * @see https://doc.babylonjs.com/how_to/gui#tracking-positions
          */
         get linkOffsetY(): string | number;
         set linkOffsetY(value: string | number);
         /**
          * Gets or sets a value indicating the offset in pixels on Y axis to the linked mesh
-         * @see http://doc.babylonjs.com/how_to/gui#tracking-positions
+         * @see https://doc.babylonjs.com/how_to/gui#tracking-positions
          */
         get linkOffsetYInPixels(): number;
         set linkOffsetYInPixels(value: number);
@@ -75548,7 +76165,7 @@ declare module BABYLON.GUI {
         /**
          * Link current control with a target mesh
          * @param mesh defines the mesh to link with
-         * @see http://doc.babylonjs.com/how_to/gui#tracking-positions
+         * @see https://doc.babylonjs.com/how_to/gui#tracking-positions
          */
         linkWithMesh(mesh: BABYLON.Nullable<BABYLON.AbstractMesh>): void;
         /** @hidden */
@@ -75675,7 +76292,7 @@ declare module BABYLON.GUI {
 declare module BABYLON.GUI {
     /**
      * Root class for 2D containers
-     * @see http://doc.babylonjs.com/how_to/gui#containers
+     * @see https://doc.babylonjs.com/how_to/gui#containers
      */
     export class Container extends Control {
         name?: string | undefined;
@@ -76047,7 +76664,7 @@ declare module BABYLON.GUI {
         get svgAttributesComputationCompleted(): boolean;
         /**
          * Gets or sets a boolean indicating if the image can force its container to adapt its size
-         * @see http://doc.babylonjs.com/how_to/gui#image
+         * @see https://doc.babylonjs.com/how_to/gui#image
          */
         get autoScale(): boolean;
         set autoScale(value: boolean);
@@ -76080,19 +76697,19 @@ declare module BABYLON.GUI {
         private _getSVGAttribs;
         /**
          * Gets or sets the cell width to use when animation sheet is enabled
-         * @see http://doc.babylonjs.com/how_to/gui#image
+         * @see https://doc.babylonjs.com/how_to/gui#image
          */
         get cellWidth(): number;
         set cellWidth(value: number);
         /**
          * Gets or sets the cell height to use when animation sheet is enabled
-         * @see http://doc.babylonjs.com/how_to/gui#image
+         * @see https://doc.babylonjs.com/how_to/gui#image
          */
         get cellHeight(): number;
         set cellHeight(value: number);
         /**
          * Gets or sets the cell id to use (this will turn on the animation sheet mode)
-         * @see http://doc.babylonjs.com/how_to/gui#image
+         * @see https://doc.babylonjs.com/how_to/gui#image
          */
         get cellId(): number;
         set cellId(value: number);
@@ -76704,13 +77321,13 @@ declare module BABYLON.GUI {
         set value(value: BABYLON.Color3);
         /**
          * Gets or sets control width
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get width(): string | number;
         set width(value: string | number);
         /**
          * Gets or sets control height
-         * @see http://doc.babylonjs.com/how_to/gui#position-and-size
+         * @see https://doc.babylonjs.com/how_to/gui#position-and-size
          */
         get height(): string | number;
         /** Gets or sets control height */
@@ -77215,7 +77832,7 @@ declare module BABYLON.GUI {
         _setSelectorButtonBackground(selectorNb: number, color: string): void;
     }
     /** Class used to hold the controls for the checkboxes, radio buttons and sliders
-     * @see http://doc.babylonjs.com/how_to/selector
+     * @see https://doc.babylonjs.com/how_to/selector
     */
     export class SelectionPanel extends Rectangle {
         /** name of SelectionPanel */
@@ -77892,7 +78509,7 @@ declare module BABYLON.GUI {
 declare module BABYLON.GUI {
     /**
      * Class used to manage 3D user interface
-     * @see http://doc.babylonjs.com/how_to/gui3d
+     * @see https://doc.babylonjs.com/how_to/gui3d
      */
     export class GUI3DManager implements BABYLON.IDisposable {
         private _scene;
@@ -78034,19 +78651,19 @@ declare module BABYLON.GUI {
         private _behaviors;
         /**
          * Gets the list of attached behaviors
-         * @see http://doc.babylonjs.com/features/behaviour
+         * @see https://doc.babylonjs.com/features/behaviour
          */
         get behaviors(): BABYLON.Behavior<Control3D>[];
         /**
          * Attach a behavior to the control
-         * @see http://doc.babylonjs.com/features/behaviour
+         * @see https://doc.babylonjs.com/features/behaviour
          * @param behavior defines the behavior to attach
          * @returns the current control
          */
         addBehavior(behavior: BABYLON.Behavior<Control3D>): Control3D;
         /**
          * Remove an attached behavior
-         * @see http://doc.babylonjs.com/features/behaviour
+         * @see https://doc.babylonjs.com/features/behaviour
          * @param behavior defines the behavior to attach
          * @returns the current control
          */
@@ -78054,7 +78671,7 @@ declare module BABYLON.GUI {
         /**
          * Gets an attached behavior by name
          * @param name defines the name of the behavior to look for
-         * @see http://doc.babylonjs.com/features/behaviour
+         * @see https://doc.babylonjs.com/features/behaviour
          * @returns null if behavior was not found else the requested behavior
          */
         getBehaviorByName(name: string): BABYLON.Nullable<BABYLON.Behavior<Control3D>>;
@@ -78701,6 +79318,10 @@ declare module BABYLON {
          */
         createInstances: boolean;
         /**
+         * Defines if the loader should always compute the bounding boxes of meshes and not use the min/max values from the position accessor. Defaults to false.
+         */
+        alwaysComputeBoundingBox: boolean;
+        /**
          * Function called before loading a url referenced by the asset.
          */
         preprocessUrlAsync: (url: string) => Promise<string>;
@@ -78807,6 +79428,7 @@ declare module BABYLON {
         private _loader;
         private _progressCallback?;
         private _requests;
+        private static magicBase64Encoded;
         /**
          * Name of the loader ("gltf")
          */
@@ -78835,7 +79457,7 @@ declare module BABYLON {
         /** @hidden */
         canDirectLoad(data: string): boolean;
         /** @hidden */
-        directLoad(scene: Scene, data: string): any;
+        directLoad(scene: Scene, data: string): Promise<any>;
         /**
          * The callback that allows custom handling of the root url based on the response url.
          * @param rootUrl the original root url
@@ -80153,6 +80775,11 @@ declare module BABYLON.GLTF2 {
     }
 }
 declare module BABYLON.GLTF2.Loader.Extensions {
+        /** @hidden */
+        interface IEXTLightsImageBased_LightImageBased {
+            _babylonTexture?: BaseTexture;
+            _loaded?: Promise<void>;
+        }
     /**
      * [Specification](https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Vendor/EXT_lights_image_based/README.md)
      */
@@ -80451,22 +81078,45 @@ declare module BABYLON.GLTF2.Loader.Extensions {
          */
         static GetAvailableVariants(rootMesh: Mesh): string[];
         /**
+         * Gets the list of available variant tag names for this asset.
+         * @param rootMesh The glTF root mesh
+         * @returns the list of all the variant names for this model
+         */
+        getAvailableVariants(rootMesh: Mesh): string[];
+        /**
          * Select a variant given a variant tag name or a list of variant tag names.
          * @param rootMesh The glTF root mesh
          * @param variantName The variant name(s) to select.
          */
         static SelectVariant(rootMesh: Mesh, variantName: string | string[]): void;
         /**
+         * Select a variant given a variant tag name or a list of variant tag names.
+         * @param rootMesh The glTF root mesh
+         * @param variantName The variant name(s) to select.
+         */
+        selectVariant(rootMesh: Mesh, variantName: string | string[]): void;
+        /**
          * Reset back to the original before selecting a variant.
          * @param rootMesh The glTF root mesh
          */
         static Reset(rootMesh: Mesh): void;
+        /**
+         * Reset back to the original before selecting a variant.
+         * @param rootMesh The glTF root mesh
+         */
+        reset(rootMesh: Mesh): void;
         /**
          * Gets the last selected variant tag name(s) or null if original.
          * @param rootMesh The glTF root mesh
          * @returns The selected variant tag name(s).
          */
         static GetLastSelectedVariant(rootMesh: Mesh): Nullable<string | string[]>;
+        /**
+         * Gets the last selected variant tag name(s) or null if original.
+         * @param rootMesh The glTF root mesh
+         * @returns The selected variant tag name(s).
+         */
+        getLastSelectedVariant(rootMesh: Mesh): Nullable<string | string[]>;
         private static _GetExtensionMetadata;
         /** @hidden */
         _loadMeshPrimitiveAsync(context: string, name: string, node: INode, mesh: IMesh, primitive: IMeshPrimitive, assign: (babylonMesh: AbstractMesh) => void): Nullable<Promise<AbstractMesh>>;
@@ -81534,6 +82184,7 @@ declare module BABYLON.GLTF2.Exporter {
          */
         static _GetRightHandedQuaternionArrayFromRef(quaternion: number[]): void;
         static _NormalizeTangentFromRef(tangent: Vector4): void;
+        static _GetRightHandedMatrixFromRef(matrix: Matrix): void;
     }
 }
 declare module BABYLON.GLTF2.Exporter {
@@ -81585,6 +82236,10 @@ declare module BABYLON.GLTF2.Exporter {
          * Stores all the texture samplers
          */
         _samplers: ISampler[];
+        /**
+         * Stores all the generated glTF skins
+         */
+        _skins: ISkin[];
         /**
          * Stores all the generated animation samplers, which is referenced by glTF animations
          */
@@ -81744,11 +82399,11 @@ declare module BABYLON.GLTF2.Exporter {
          * Returns the bytelength of the data
          * @param vertexBufferKind Indicates what kind of vertex data is being passed in
          * @param meshAttributeArray Array containing the attribute data
+         * @param byteStride Specifies the space between data
          * @param binaryWriter The buffer to write the binary data to
-         * @param indices Used to specify the order of the vertex data
          * @param convertToRightHandedSystem Converts the values to right-handed
          */
-        writeAttributeData(vertexBufferKind: string, meshAttributeArray: FloatArray, byteStride: number, binaryWriter: _BinaryWriter, convertToRightHandedSystem: boolean): void;
+        writeAttributeData(vertexBufferKind: string, attributeComponentKind: AccessorComponentType, meshAttributeArray: FloatArray, stride: number, binaryWriter: _BinaryWriter, convertToRightHandedSystem: boolean, babylonTransformNode: TransformNode): void;
         /**
          * Generates glTF json data
          * @param shouldUseGlb Indicates whether the json should be written for a glb file
@@ -81790,6 +82445,7 @@ declare module BABYLON.GLTF2.Exporter {
         /**
          * Creates a bufferview based on the vertices type for the Babylon mesh
          * @param kind Indicates the type of vertices data
+         * @param componentType Indicates the numerical type used to store the data
          * @param babylonTransformNode The Babylon mesh to get the vertices data from
          * @param binaryWriter The buffer to write the bufferview data to
          * @param convertToRightHandedSystem Converts the values to right-handed
@@ -81851,6 +82507,14 @@ declare module BABYLON.GLTF2.Exporter {
          * @returns glTF node
          */
         private createNodeAsync;
+        /**
+         * Creates a glTF skin from a Babylon skeleton
+         * @param babylonScene Babylon Scene
+         * @param nodes Babylon transform nodes
+         * @param binaryWriter Buffer to write binary data to
+         * @returns Node mapping of unique id to index
+         */
+        private createSkinsAsync;
     }
     /**
      * @hidden
@@ -81896,6 +82560,12 @@ declare module BABYLON.GLTF2.Exporter {
          * @param byteOffset If defined, specifies where to set the value as an offset.
          */
         setUInt8(entry: number, byteOffset?: number): void;
+        /**
+         * Stores an UInt16 in the array buffer
+         * @param entry
+         * @param byteOffset If defined, specifies where to set the value as an offset.
+         */
+        setUInt16(entry: number, byteOffset?: number): void;
         /**
          * Gets an UInt32 in the array buffer
          * @param entry
@@ -82192,6 +82862,25 @@ declare module BABYLON.GLTF2.Exporter.Extensions {
         private _getTextureIndex;
         postExportTexture?(context: string, textureInfo: ITextureInfo, babylonTexture: Texture): void;
         postExportMaterialAdditionalTextures?(context: string, node: IMaterial, babylonMaterial: Material): BaseTexture[];
+        postExportMaterialAsync?(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial>;
+    }
+}
+declare module BABYLON.GLTF2.Exporter.Extensions {
+    /**
+     * @hidden
+     */
+    export class KHR_materials_unlit implements IGLTFExporterExtensionV2 {
+        /** Name of this extension */
+        readonly name: string;
+        /** Defines whether this extension is enabled */
+        enabled: boolean;
+        /** Defines whether this extension is required */
+        required: boolean;
+        private _wasUsed;
+        constructor(exporter: _Exporter);
+        /** @hidden */
+        get wasUsed(): boolean;
+        dispose(): void;
         postExportMaterialAsync?(context: string, node: IMaterial, babylonMaterial: Material): Promise<IMaterial>;
     }
 }
@@ -83119,6 +83808,288 @@ declare module BABYLON.GLTF2 {
         validateBytes: (data: Uint8Array, options?: IGLTFValidationOptions) => Promise<IGLTFValidationResults>;
         validateString: (json: string, options?: IGLTFValidationOptions) => Promise<IGLTFValidationResults>;
     }
+
+    /**
+     * Interfaces from the EXT_lights_image_based extension
+     */
+
+    /** @hidden */
+    interface IEXTLightsImageBased_LightReferenceImageBased {
+        light: number;
+    }
+
+    /** @hidden */
+    interface IEXTLightsImageBased_LightImageBased extends IChildRootProperty {
+        intensity: number;
+        rotation: number[];
+        specularImageSize: number;
+        specularImages: number[][];
+        irradianceCoefficients: number[][];
+    }
+
+    /** @hidden */
+    interface IEXTLightsImageBased {
+        lights: IEXTLightsImageBased_LightImageBased[];
+    }
+
+    /**
+     * Interfaces from the EXT_mesh_gpu_instancing extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IEXTMeshGpuInstancing {
+        mesh?: number;
+        attributes: { [name: string]: number };
+    }
+
+    /**
+     * Interfaces from the KHR_draco_mesh_compression extension
+     */
+
+    /** @hidden */
+    interface IKHRDracoMeshCompression {
+        bufferView: number;
+        attributes: { [name: string]: number };
+    }
+
+    /**
+     * Interfaces from the KHR_lights_punctual extension
+     */
+
+    /** @hidden */
+    const enum IKHRLightsPunctual_LightType {
+        DIRECTIONAL = "directional",
+        POINT = "point",
+        SPOT = "spot"
+    }
+
+    /** @hidden */
+    interface IKHRLightsPunctual_LightReference {
+        light: number;
+    }
+
+    /** @hidden */
+    interface IKHRLightsPunctual_Light extends IChildRootProperty {
+        type: IKHRLightsPunctual_LightType;
+        color?: number[];
+        intensity?: number;
+        range?: number;
+        spot?: {
+            innerConeAngle?: number;
+            outerConeAngle?: number;
+        };
+    }
+
+    /** @hidden */
+    interface IKHRLightsPunctual {
+        lights: IKHRLightsPunctual_Light[];
+    }
+
+    /**
+     * Interfaces from the KHR_materials_clearcoat extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IKHRMaterialsClearcoat {
+        clearcoatFactor: number;
+        clearcoatTexture: ITextureInfo;
+        clearcoatRoughnessFactor: number;
+        clearcoatRoughnessTexture: ITextureInfo;
+        clearcoatNormalTexture: IMaterialNormalTextureInfo;
+    }
+
+    /**
+     * Interfaces from the KHR_materials_ior extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IKHRMaterialsIor {
+        ior: number;
+    }
+
+    /**
+     * Interfaces from the KHR_materials_pbrSpecularGlossiness extension
+     */
+
+    /** @hidden */
+    interface IKHRMaterialsPbrSpecularGlossiness {
+        diffuseFactor: number[];
+        diffuseTexture: ITextureInfo;
+        specularFactor: number[];
+        glossinessFactor: number;
+        specularGlossinessTexture: ITextureInfo;
+    }
+
+    /**
+     * Interfaces from the KHR_materials_sheen extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IKHRMaterialsSheen {
+        sheenColorFactor?: number[];
+        sheenTexture?: ITextureInfo;
+        sheenRoughnessFactor?: number;
+    }
+
+    /**
+     * Interfaces from the KHR_materials_specular extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IKHRMaterialsSpecular {
+        specularFactor: number;
+        specularColorFactor: number[];
+        specularTexture: ITextureInfo;
+    }
+
+    /**
+     * Interfaces from the KHR_materials_transmission extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IKHRMaterialsTransmission {
+        transmissionFactor?: number;
+        transmissionTexture?: ITextureInfo;
+    }
+
+    /**
+     * Interfaces from the KHR_materials_variants extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IKHRMaterialVariants_Mapping {
+        tags: string[];
+        material: number;
+    }
+
+    /** @hidden */
+    interface IKHRMaterialVariants {
+        mapping: IKHRMaterialVariants_Mapping[];
+    }
+
+    /**
+     * Interfaces from the KHR_texture_basisu extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IKHRTextureBasisU {
+        source: number;
+    }
+
+    /**
+     * Interfaces from the KHR_texture_transform extension
+     */
+
+    /** @hidden */
+    interface IKHRTextureTransform {
+        offset?: number[];
+        rotation?: number;
+        scale?: number[];
+        texCoord?: number;
+    }
+
+    /**
+     * Interfaces from the KHR_xmp extension
+     * !!! Experimental Extension Subject to Changes !!!
+     */
+
+    /** @hidden */
+    interface IKHRXmp_Data {
+        [key: string]: unknown;
+    }
+
+    /** @hidden */
+    interface IKHRXmp_Gltf {
+        packets: IKHRXmp_Data[];
+    }
+
+    /** @hidden */
+    interface IKHRXmp_Node {
+        packet: number;
+    }
+
+    /**
+     * Interfaces from the MSFT_audio_emitter extension
+     */
+
+    /** @hidden */
+    interface IMSFTAudioEmitter_ClipReference {
+        clip: number;
+        weight?: number;
+    }
+
+    /** @hidden */
+    interface IMSFTAudioEmitter_EmittersReference {
+        emitters: number[];
+    }
+
+    /** @hidden */
+    const enum IMSFTAudioEmitter_DistanceModel {
+        linear = "linear",
+        inverse = "inverse",
+        exponential = "exponential",
+    }
+
+    /** @hidden */
+    interface IMSFTAudioEmitter_Emitter {
+        name?: string;
+        distanceModel?: IMSFTAudioEmitter_DistanceModel;
+        refDistance?: number;
+        maxDistance?: number;
+        rolloffFactor?: number;
+        innerAngle?: number;
+        outerAngle?: number;
+        loop?: boolean;
+        volume?: number;
+        clips: IMSFTAudioEmitter_ClipReference[];
+    }
+
+    /** @hidden */
+    const enum IMSFTAudioEmitter_AudioMimeType {
+        WAV = "audio/wav",
+    }
+
+    /** @hidden */
+    interface IMSFTAudioEmitter_Clip extends IProperty {
+        uri?: string;
+        bufferView?: number;
+        mimeType?: IMSFTAudioEmitter_AudioMimeType;
+    }
+
+    /** @hidden */
+    const enum IMSFTAudioEmitter_AnimationEventAction {
+        play = "play",
+        pause = "pause",
+        stop = "stop",
+    }
+
+    /** @hidden */
+    interface IMSFTAudioEmitter_AnimationEvent {
+        action: IMSFTAudioEmitter_AnimationEventAction;
+        emitter: number;
+        time: number;
+        startOffset?: number;
+    }
+
+    /**
+     * Interfaces from the MSFT_lod extension
+     */
+
+    /** @hidden */
+    interface IMSFTLOD {
+        ids: number[];
+    }
+
+
+
 }
 
 declare module BABYLON {


### PR DESCRIPTION
By request of https://forum.babylonjs.com/t/reinitializing-engine-in-playground-typescript/12289/4:

Added Playground examples to

- /babylon101/First

- /how_to/using_the_physics_engine

Please note: On the Physics Engine page, the newly added Playground (https://www.babylonjs-playground.com/#3ZW889#7) works fine if you click on the link. However, when you click the Eyeball preview button, it gives an error. Perhaps, babylonjs-playground.com is using `renderingCanvas` and doc.babylonjs.com is using `renderCanvas`.