### PR TITLE
Mention how to register manually created Octree in docs

### DIFF
--- a/content/How_To/scene/Optimizing_Your_Scene_with_Octrees.md
+++ b/content/How_To/scene/Optimizing_Your_Scene_with_Octrees.md
@@ -49,6 +49,18 @@ For the specific case of ground meshes, Babylon.js provides a class called ```BA
 By calling ```groundMesh.optimize(chunkSize)``` where chunkSize defines the number of submeshes you want, the mesh will be optimized for rendering, picking and collisions by creating an internal octree (Be sure to select a correct chunkSize).
 
 ## Using Octrees Manually
+
+For your manually created Octree to activate correctly, you will need to register it like so:
+```ts
+let component = scene._getComponent(SceneComponentConstants.NAME_OCTREE);
+if (!component) {
+  component = new OctreeSceneComponent(scene);
+  scene._addComponent(component);
+}
+
+component.register();
+```
+
 You can also use octrees from your code to get a list of meshes or submeshes.
 
 Here are the helpful functions you can find on an octree:


### PR DESCRIPTION
When using a manually created Octree, I was experiencing a bug where only parts of the scene were visible and the rest would appear for a moment and then disappear.

I read through the forums for any reports of this, and I found this reply: 
https://forum.babylonjs.com/t/manually-created-octrees-no-longer-working-in-bjs-4-0/5412/10

Adding that code seemed to fix the issue.

Additionally: it would be nice if there was an Edit button in the docs pages. It could just link to the edit button on Github for the specific file. 