### PR TITLE
Fix PG not working with importing animations

### DIFF
--- a/content/How_To/Importer/Load_From_Any_File_Type.md
+++ b/content/How_To/Importer/Load_From_Any_File_Type.md
@@ -119,7 +119,7 @@ You can customize the import process using options and callbacks
 ```javascript
 BABYLON.SceneLoader.ImportAnimations("./", "Elf_run.gltf", scene);
 ```
-[Demo](https://www.babylonjs-playground.com/#UGD0Q0#2)
+[Demo](https://www.babylonjs-playground.com/#UGD0Q0#62)
 
 ## SceneLoader.AppendAsync
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/playground-example-is-broken-for-gltf-animation/13984